### PR TITLE
Add KMeansPolis implementation that more closely maps to Polis algorithm

### DIFF
--- a/reddwarf/cluster.py
+++ b/reddwarf/cluster.py
@@ -1,0 +1,59 @@
+import numpy as np
+from sklearn.cluster import KMeans
+
+class KMeansPolis(KMeans):
+    def __init__(self, n_clusters=2, tol_centers=0.01, max_iter=20, **kwargs):
+        """
+        Polis-like KMeans that stops when cluster centers move less than `tol_centers`.
+
+        This modifies the default KMeans from a **stopping
+        condition** (between iterations) that's inertia-based (`tol`), to direct
+        cluster center movement comparison (`tol_centers`).
+
+        Reference:
+            <https://github.com/compdemocracy/polis/blob/56ed5c2618a0a372448d26bdaad3ae8a34c0ed33/math/src/polismath/math/clusters.clj#L68-L76>
+
+        Parameters:
+            n_clusters: Number of clusters.
+            tol_centers: Minimum movement for centers to continue iterating.
+            max_iter: Maximum iterations.
+            kwargs: Other parameters for sklearn's KMeans.
+
+        Returns:
+
+        """
+        super().__init__(n_clusters=n_clusters, max_iter=max_iter, tol=0, **kwargs)
+        self.tol_centers = tol_centers  # Custom stopping threshold for centers
+
+    def _fit(self, X, y=None):
+        """Overrides the main fit loop to check center movement."""
+        # Initialize clusters using sklearn's normal method
+        super()._check_params(X)
+        self._n_threads = 1  # Ensure compatibility with sklearn threading
+
+        best_inertia = None
+        self.n_iter_ = 0
+        old_centers = None
+
+        for i in range(self.max_iter):
+            self.n_iter_ = i + 1
+
+            # Run one iteration of k-means (sklearn's internal logic)
+            labels, new_centers, inertia = self._kmeans_single_lloyd(
+                X, self.n_clusters, self.init, self.random_state, self.n_init,
+                max_iter=1, verbose=self.verbose, tol=0, x_squared_norms=None)
+
+            # Check stopping condition (center movement)
+            if old_centers is not None:
+                center_shifts = np.linalg.norm(new_centers - old_centers, axis=1)
+                if np.all(center_shifts < self.tol_centers):
+                    break  # Stop early, like `same-clustering?`
+
+            old_centers = new_centers
+            best_inertia = inertia
+
+        # Store final model state
+        self.cluster_centers_ = new_centers
+        self.inertia_ = best_inertia
+        self.labels_ = labels
+        return self

--- a/reddwarf/utils.py
+++ b/reddwarf/utils.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 from sklearn.impute import SimpleImputer
-from sklearn.cluster import KMeans
+from reddwarf.cluster import KMeansPolis
 from sklearn.metrics import silhouette_score
 from sklearn.decomposition import PCA
 from typing import List, Dict, Tuple, Optional, Literal, TypeAlias
@@ -292,7 +292,7 @@ def run_kmeans(
         # Use the default strategy in sklearn.
         init_arg = "k-means++"
     # TODO: Set random_state to a value eventually, so calculation is deterministic.
-    kmeans = KMeans(
+    kmeans = KMeansPolis(
         n_clusters=n_clusters,
         random_state=random_state,
         init=init_arg,


### PR DESCRIPTION
This is low priority, and will be left as a draft for discussion, for data science folks who know more than me to chime in on.

KMeans runs a certain number of iterations up to a max, but stops when certain conditions are met between successive iterations.
- In sklearn's KMeans implementation, the inertia is used to determine when to stop.
- In Polis' KMeans implementation, the cluster center movement falling within a tolerance determines when to stop.

This might lead to slightly different results, which might matter later. Leaving this here for posterity.

Might investigate this further when we have unit tests over `run_kmeans()` that test various sizes of conversations.


---
This PR was written with the help of ChatGPT:
See: https://chatgpt.com/c/67be1cc5-b00c-800b-95ba-a0267edfb836

> - **Clojure's [Polis] `threshold` is per-cluster-center movement**, while **sklearn's `tol` is based on total inertia change**.
> - If clusters shift slightly but inertia barely changes, **sklearn might stop earlier than [Polis'] `same-clustering?`**.
> - If inertia fluctuates while centers stay put, **sklearn might run longer than [Polis'] `same-clustering?`**.

> If **cluster centers move** but **inertia remains unchanged**, it means the reassignment of points to clusters **does not significantly affect the total squared distances**.
> 
> ### **Possible Scenarios Where This Happens:**
>
> 1.  **Centers Shift Without Changing Assignments**
>     *   If all data points remain assigned to the **same clusters** despite center movement, inertia stays the same.
>     *   Example: The cluster centers **jitter slightly** but the **sum of squared distances** doesn’t change.
> 2.  **Symmetric Reassignment of Points**
>     *   Suppose some points **switch clusters**, but the overall distribution remains similar.
>     *   Example: Two clusters swap a few points, but the distance to the centers remains the same.
> 3.  **Flat Regions in the Data**
>     *   If the dataset has **a uniform spread** of points, minor shifts in cluster centers might **not impact the overall distance sum**.