### PR TITLE
Add PCA unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add color legend for labels in `data_presenter.generate_figure()`. [`d55f535`](https://github.com/polis-community/red-dwarf/pull/24/commits/d55f53588de72620abb984d7c1ac27f8a31d5478) ([#22](https://github.com/polis-community/red-dwarf/issues/22))
 - Implement calculations of all comment statistics. ([#25](https://github.com/polis-community/red-dwarf/pull/25))
 - Implement `utils.select_representative_statements()` to reproduce polismath output. ([#25](https://github.com/polis-community/red-dwarf/pull/25))
+- Add unit tests for `agora.run_clustering()`.
 
 ### Chores
 - Restructure `utils.py` into separate files. ([#26](https://github.com/polis-community/red-dwarf/pull/26))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add color legend for labels in `data_presenter.generate_figure()`. [`d55f535`](https://github.com/polis-community/red-dwarf/pull/24/commits/d55f53588de72620abb984d7c1ac27f8a31d5478) ([#22](https://github.com/polis-community/red-dwarf/issues/22))
 - Implement calculations of all comment statistics. ([#25](https://github.com/polis-community/red-dwarf/pull/25))
 - Implement `utils.select_representative_statements()` to reproduce polismath output. ([#25](https://github.com/polis-community/red-dwarf/pull/25))
+- Add unit tests for `utils.run_pca()` to test against real polismath data.
 - Add unit tests for `agora.run_clustering()`.
 
 ### Chores

--- a/reddwarf/agora.py
+++ b/reddwarf/agora.py
@@ -42,7 +42,7 @@ def run_clustering_v1(
         min_user_vote_threshold=options.get("min_user_vote_threshold", DEFAULT_MIN_USER_VOTE_THRESHOLD),
         active_statement_ids=all_statement_ids,
     )
-    projected_data, _, _ = utils.run_pca(vote_matrix=vote_matrix)
+    projected_data, *_ = utils.run_pca(vote_matrix=vote_matrix)
     projected_data = utils.scale_projected_data(
         projected_data=projected_data,
         vote_matrix=vote_matrix,

--- a/reddwarf/polis.py
+++ b/reddwarf/polis.py
@@ -153,7 +153,7 @@ class PolisClient():
         return participants_df
 
     def run_pca(self):
-        projected_data, components, explained_variance = utils.run_pca(
+        projected_data, components, explained_variance, means, *_ = utils.run_pca(
             vote_matrix=self.matrix,
             n_components=self.n_components,
         )
@@ -161,6 +161,7 @@ class PolisClient():
         self.eigenvectors = components
         self.eigenvalues = explained_variance
         self.projected_data = projected_data
+        self.means = means
 
     def scale_projected_data(self):
         scaled_data = utils.scale_projected_data(

--- a/reddwarf/utils/matrix.py
+++ b/reddwarf/utils/matrix.py
@@ -139,6 +139,20 @@ def get_unvoted_statement_ids(vote_matrix: VoteMatrix) -> List[int]:
 
     return null_column_ids
 
+def simple_filter_matrix(
+        vote_matrix: VoteMatrix,
+        statement_ids_mod_out: list[int] = [],
+) -> VoteMatrix:
+    """
+    The simple filter on the vote_matrix that is used by Polis prior to running PCA.
+    """
+    for tid in statement_ids_mod_out:
+        # Zero out column only if already exists (ie. has votes)
+        if tid in vote_matrix.columns:
+            vote_matrix.loc[:, tid] = 0
+
+    return vote_matrix
+
 def filter_matrix(
         vote_matrix: VoteMatrix,
         min_user_vote_threshold: int = 7,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,3 +9,12 @@ def small_convo_math_data():
         data = json.load(f)
 
     return data, path, filename
+
+@pytest.fixture
+def medium_convo_math_data():
+    path = "tests/fixtures/above-100-ptpts"
+    filename = "math-pca2.json"
+    with open(f"{path}/{filename}", 'r') as f:
+        data = json.load(f)
+
+    return data, path, filename

--- a/tests/test_agora.py
+++ b/tests/test_agora.py
@@ -1,19 +1,25 @@
 from tests.fixtures import small_convo_math_data, medium_convo_math_data
-from reddwarf.agora import run_clustering_v1, Conversation
+from reddwarf import agora
 from reddwarf.polis import PolisClient
 
-def test_run_clustering_real_data_small(small_convo_math_data):
-    expected_cluster_sizes = [4, 10, 5]
-    _, data_path, *_ = small_convo_math_data
+# A helper to generate votes list.
+def build_votes(data_fixture):
+    _, data_path, *_ = data_fixture
 
     client = PolisClient()
     client.load_data(filepaths=[f"{data_path}/votes.json"])
 
-    convo: Conversation = {
+    return client.data_loader.votes_data
+
+def test_run_clustering_real_data_small(small_convo_math_data):
+    expected_cluster_sizes = [4, 10, 5]
+    votes = build_votes(small_convo_math_data)
+
+    convo: agora.Conversation = {
         "id": "dummy",
-        "votes": client.data_loader.votes_data, # type:ignore
+        "votes": votes, # type:ignore
     }
-    results = run_clustering_v1(conversation=convo)
+    results = agora.run_clustering_v1(conversation=convo)
 
     assert len(expected_cluster_sizes) == len(results["clusters"])
 
@@ -23,19 +29,45 @@ def test_run_clustering_real_data_small(small_convo_math_data):
 
 def test_run_clustering_real_data_medium(medium_convo_math_data):
     expected_cluster_sizes = [60, 39, 37, 37, 3]
-    _, data_path, *_ = medium_convo_math_data
+    votes = build_votes(medium_convo_math_data)
 
-    client = PolisClient()
-    client.load_data(filepaths=[f"{data_path}/votes.json"])
-
-    convo: Conversation = {
+    convo: agora.Conversation = {
         "id": "dummy",
-        "votes": client.data_loader.votes_data, # type:ignore
+        "votes": votes, # type:ignore
     }
-    results = run_clustering_v1(conversation=convo)
+    results = agora.run_clustering_v1(conversation=convo)
 
     assert len(expected_cluster_sizes) == len(results["clusters"])
 
     for cluster_id, expected_cluster_size in enumerate(expected_cluster_sizes):
         actual_cluster_size = len(results["clusters"][cluster_id]["participants"])
         assert actual_cluster_size == expected_cluster_size
+
+def test_run_clustering_real_data_no_min_threshold_option(small_convo_math_data):
+    expected_cluster_sizes = [24, 7, 4]
+    votes = build_votes(small_convo_math_data)
+
+    convo: agora.Conversation = {
+        "id": "dummy",
+        "votes": votes, # type:ignore
+    }
+    results = agora.run_clustering_v1(conversation=convo, options={"min_user_vote_threshold": 0})
+
+    assert len(expected_cluster_sizes) == len(results["clusters"])
+
+    for cluster_id, expected_cluster_size in enumerate(expected_cluster_sizes):
+        actual_cluster_size = len(results["clusters"][cluster_id]["participants"])
+        assert actual_cluster_size == expected_cluster_size
+
+def test_run_clustering_real_data_max_clusters_option(medium_convo_math_data):
+    max_cluster_count = 3
+    expected_cluster_count = max_cluster_count
+    votes = build_votes(medium_convo_math_data)
+
+    convo: agora.Conversation = {
+        "id": "dummy",
+        "votes": votes, # type:ignore
+    }
+    results = agora.run_clustering_v1(conversation=convo, options={"max_clusters": max_cluster_count})
+
+    assert expected_cluster_count == len(results["clusters"])

--- a/tests/test_agora.py
+++ b/tests/test_agora.py
@@ -1,0 +1,41 @@
+from tests.fixtures import small_convo_math_data, medium_convo_math_data
+from reddwarf.agora import run_clustering_v1, Conversation
+from reddwarf.polis import PolisClient
+
+def test_run_clustering_real_data_small(small_convo_math_data):
+    expected_cluster_sizes = [4, 10, 5]
+    _, data_path, *_ = small_convo_math_data
+
+    client = PolisClient()
+    client.load_data(filepaths=[f"{data_path}/votes.json"])
+
+    convo: Conversation = {
+        "id": "dummy",
+        "votes": client.data_loader.votes_data, # type:ignore
+    }
+    results = run_clustering_v1(conversation=convo)
+
+    assert len(expected_cluster_sizes) == len(results["clusters"])
+
+    for cluster_id, expected_cluster_size in enumerate(expected_cluster_sizes):
+        actual_cluster_size = len(results["clusters"][cluster_id]["participants"])
+        assert actual_cluster_size == expected_cluster_size
+
+def test_run_clustering_real_data_medium(medium_convo_math_data):
+    expected_cluster_sizes = [60, 39, 37, 37, 3]
+    _, data_path, *_ = medium_convo_math_data
+
+    client = PolisClient()
+    client.load_data(filepaths=[f"{data_path}/votes.json"])
+
+    convo: Conversation = {
+        "id": "dummy",
+        "votes": client.data_loader.votes_data, # type:ignore
+    }
+    results = run_clustering_v1(conversation=convo)
+
+    assert len(expected_cluster_sizes) == len(results["clusters"])
+
+    for cluster_id, expected_cluster_size in enumerate(expected_cluster_sizes):
+        actual_cluster_size = len(results["clusters"][cluster_id]["participants"])
+        assert actual_cluster_size == expected_cluster_size

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -313,52 +313,10 @@ def test_impute_missing_votes_no_vote_statement_error():
     with pytest.raises(RedDwarfError):
         utils.impute_missing_votes(vote_matrix=initial_matrix)
 
-def test_run_pca_toy():
-    # Pre-calculated
-    expected_projections = [
-        [ 1.238168, -0.173377],
-        [-0.998131, -0.268031],
-        [-0.123951,  0.205794],
-        [-0.116086,  0.235614],
-    ]
-    expected_eigenvectors = [
-        [0.87418057, -0.48400607, -0.0393249],
-        [0.47382435,  0.86790524, -0.1491005],
-    ]
-    expected_eigenvalues = [ 0.85272226, 0.06658833 ]
-
-    initial_matrix = pd.DataFrame(
-        [
-            [ 1, 0,  0],
-            [-1, 1,  0.1],
-            [ 0, 1,  0.1],
-            [ 0, 1, -0.1],
-        ],
-        columns=[0, 1, 2], # statement_ids
-        index=[0, 1, 2, 3], # participant_ids
-        dtype=float,
-    )
-    projected_data, eigenvectors, eigenvalues = utils.run_pca(vote_matrix=initial_matrix)
-    assert_allclose(projected_data.values, expected_projections, rtol=10**-5)
-    assert_allclose(eigenvectors, expected_eigenvectors, rtol=10**-5)
-    assert_allclose(eigenvalues, expected_eigenvalues, rtol=10**-5)
-
-@pytest.mark.skip
-def test_run_pca_real_data_below_100_participants():
-    raise
-
-@pytest.mark.skip
-def test_run_pca_real_data_above_100_participants():
-    raise
-
 @pytest.mark.skip
 def test_run_kmeans():
     raise
 
 @pytest.mark.skip
 def test_find_optimal_k():
-    raise
-
-@pytest.mark.skip
-def test_scale_projected_data():
     raise

--- a/tests/utils/test_pca.py
+++ b/tests/utils/test_pca.py
@@ -6,7 +6,6 @@ from tests.fixtures import small_convo_math_data, medium_convo_math_data
 from reddwarf.utils import pca as PcaUtils
 from reddwarf.utils import matrix as MatrixUtils
 from reddwarf.polis import PolisClient
-from reddwarf import utils
 
 
 def test_run_pca_toy():
@@ -48,9 +47,9 @@ def test_run_pca_real_data_below_100_participants(small_convo_math_data):
 
     client = PolisClient()
     client.load_data(filepaths=[f"{data_path}/votes.json"])
-    real_vote_matrix = utils.generate_raw_matrix(votes=client.data_loader.votes_data)
+    real_vote_matrix = MatrixUtils.generate_raw_matrix(votes=client.data_loader.votes_data)
 
-    real_vote_matrix = utils.simple_filter_matrix(
+    real_vote_matrix = MatrixUtils.simple_filter_matrix(
         vote_matrix=real_vote_matrix,
         statement_ids_mod_out=statement_ids_mod_out,
     )
@@ -72,9 +71,9 @@ def test_run_pca_real_data_above_100_participants(medium_convo_math_data):
 
     client = PolisClient()
     client.load_data(filepaths=[f"{data_path}/votes.json"])
-    real_vote_matrix = utils.generate_raw_matrix(votes=client.data_loader.votes_data)
+    real_vote_matrix = MatrixUtils.generate_raw_matrix(votes=client.data_loader.votes_data)
 
-    real_vote_matrix = utils.simple_filter_matrix(
+    real_vote_matrix = MatrixUtils.simple_filter_matrix(
         vote_matrix=real_vote_matrix,
         statement_ids_mod_out=statement_ids_mod_out,
     )
@@ -107,11 +106,11 @@ def test_run_pca_real_data_testing():
     # client.load_data(report_id="r4zdxrdscmukmkakmbz3k") # 145 voters, 0/117 meta WORKS
     client.load_data(report_id="r45ru4zfmutun54ttskne") # 336 voters, 15/148 meta NOPE 76/148 mismatch
     # client.load_data(report_id="") # x voters, x/x meta ...
-    real_vote_matrix = utils.generate_raw_matrix(votes=client.data_loader.votes_data)
+    real_vote_matrix = MatrixUtils.generate_raw_matrix(votes=client.data_loader.votes_data)
     math_data = client.data_loader.math_data
     expected_pca = math_data["pca"]
 
-    real_vote_matrix = utils.simple_filter_matrix(
+    real_vote_matrix = MatrixUtils.simple_filter_matrix(
         vote_matrix=real_vote_matrix,
         statement_ids_mod_out=math_data["mod-out"],
     )

--- a/tests/utils/test_pca.py
+++ b/tests/utils/test_pca.py
@@ -1,0 +1,130 @@
+import pandas as pd
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+from tests.fixtures import small_convo_math_data, medium_convo_math_data
+from reddwarf.utils import pca as PcaUtils
+from reddwarf.utils import matrix as MatrixUtils
+from reddwarf.polis import PolisClient
+from reddwarf import utils
+
+
+def test_run_pca_toy():
+    # Pre-calculated
+    expected_projections = [
+        [ 1.238168, -0.173377],
+        [-0.998131, -0.268031],
+        [-0.123951,  0.205794],
+        [-0.116086,  0.235614],
+    ]
+    expected_eigenvectors = [
+        [0.87418057, -0.48400607, -0.0393249],
+        [0.47382435,  0.86790524, -0.1491005],
+    ]
+    expected_eigenvalues = [ 0.85272226, 0.06658833 ]
+
+    initial_matrix = pd.DataFrame(
+        [
+            [ 1, 0,  0],
+            [-1, 1,  0.1],
+            [ 0, 1,  0.1],
+            [ 0, 1, -0.1],
+        ],
+        columns=[0, 1, 2], # statement_ids
+        index=[0, 1, 2, 3], # participant_ids
+        dtype=float,
+    )
+    projected_data, eigenvectors, eigenvalues, *_ = PcaUtils.run_pca(vote_matrix=initial_matrix)
+    assert_allclose(projected_data.values, expected_projections, rtol=10**-5)
+    assert_allclose(eigenvectors, expected_eigenvectors, rtol=10**-5)
+    assert_allclose(eigenvalues, expected_eigenvalues, rtol=10**-5)
+
+def test_run_pca_real_data_below_100_participants(small_convo_math_data):
+    math_data, data_path, *_ = small_convo_math_data
+    expected_pca = math_data["pca"]
+
+    # Just fetch the moderated out statements from polismath (no need to recalculate here)
+    statement_ids_mod_out = math_data["mod-out"]
+
+    client = PolisClient()
+    client.load_data(filepaths=[f"{data_path}/votes.json"])
+    real_vote_matrix = utils.generate_raw_matrix(votes=client.data_loader.votes_data)
+
+    real_vote_matrix = utils.simple_filter_matrix(
+        vote_matrix=real_vote_matrix,
+        statement_ids_mod_out=statement_ids_mod_out,
+    )
+
+    _, actual_components, _, actual_means = PcaUtils.run_pca(vote_matrix=real_vote_matrix)
+
+    # We test absolute because PCA methods don't always give the same sign, and can flip.
+    assert np.absolute(actual_components[0]) == pytest.approx(np.absolute(expected_pca["comps"][0]))
+    assert np.absolute(actual_components[1]) == pytest.approx(np.absolute(expected_pca["comps"][1]))
+
+    assert np.absolute(actual_means) == pytest.approx(np.absolute(expected_pca["center"]))
+
+def test_run_pca_real_data_above_100_participants(medium_convo_math_data):
+    math_data, data_path, *_ = medium_convo_math_data
+    expected_pca = math_data["pca"]
+
+    # Just fetch the moderated out statements from polismath (no need to recalculate here)
+    statement_ids_mod_out = math_data["mod-out"]
+
+    client = PolisClient()
+    client.load_data(filepaths=[f"{data_path}/votes.json"])
+    real_vote_matrix = utils.generate_raw_matrix(votes=client.data_loader.votes_data)
+
+    real_vote_matrix = utils.simple_filter_matrix(
+        vote_matrix=real_vote_matrix,
+        statement_ids_mod_out=statement_ids_mod_out,
+    )
+
+    _, actual_components, _, actual_means = PcaUtils.run_pca(vote_matrix=real_vote_matrix)
+
+    # We test absolute because PCA methods don't always give the same sign, and can flip.
+    assert np.absolute(actual_components[0]) == pytest.approx(np.absolute(expected_pca["comps"][0]))
+    assert np.absolute(actual_components[1]) == pytest.approx(np.absolute(expected_pca["comps"][1]))
+
+    assert np.absolute(actual_means) == pytest.approx(np.absolute(expected_pca["center"]))
+
+# TODO: Find a good place to run integration tests against real remote datasets.
+@pytest.mark.skip
+def test_run_pca_real_data_testing():
+    client = PolisClient()
+    # client.load_data(report_id="r6iwc8tb22am6hpd8f7c5") # 20 voters, 0/146 meta WORKS
+    # client.load_data(report_id="r5hr48j8y8mpcffk7crmk") # 27 voters, 11/63 meta WORKS strict=no
+    # client.load_data(report_id="r7dr5tzke7pbpbajynkv8") #  69 voters, 74/133 meta NOPE 2/133 mismatch strict=yes
+    # client.load_data(report_id="r8jhyfp54cyanhu26cz3v") #  90 voters, 0/51 meta WORKS strict=no
+    # client.load_data(report_id="r2dtdbwbsrzu8bj8wmpmc") #  87 voters, 3/92 meta WORKS strict=no
+    # client.load_data(report_id="r9cnkypdddkmnefz8k2bn") # 113 voters, 0/40 meta WORKS strict=no
+    # client.load_data(report_id="r4zurrpweay6khmsaab4e") # 108 voters, 0/82 meta WORKS strict=yes
+    # client.load_data(report_id="r5ackfcj5dmawnt2de7x7") # 109 voters, 16/95 meta NOPE DIFF SHAPES? bug?
+    # client.load_data(report_id="r6bpmcmizi2kyvhzkhfr7") # 23 voters, 0/9 meta WORKS strict=yes
+    # client.load_data(report_id="r4tfrhexm3dhawcfav6dy") # 116 voters, 0/170 meta WORKS
+    # client.load_data(report_id="r7f89nk32sjuknecjbrxp") # 135 voters, 0/52 meta WORKS
+    # client.load_data(report_id="r2xzujbewezpjdc9pmzhd") # 135 voters, 3/48 meta WORKS
+    # client.load_data(report_id="r8bzudrhs8j6petppicrj") # 140 voters, 0/46 meta WORKS
+    # client.load_data(report_id="r4zdxrdscmukmkakmbz3k") # 145 voters, 0/117 meta WORKS
+    client.load_data(report_id="r45ru4zfmutun54ttskne") # 336 voters, 15/148 meta NOPE 76/148 mismatch
+    # client.load_data(report_id="") # x voters, x/x meta ...
+    real_vote_matrix = utils.generate_raw_matrix(votes=client.data_loader.votes_data)
+    math_data = client.data_loader.math_data
+    expected_pca = math_data["pca"]
+
+    real_vote_matrix = utils.simple_filter_matrix(
+        vote_matrix=real_vote_matrix,
+        statement_ids_mod_out=math_data["mod-out"],
+    )
+
+    _, actual_components, _, actual_means = PcaUtils.run_pca(vote_matrix=real_vote_matrix)
+    # powerit_pca = PcaUtils.powerit_pca(real_vote_matrix.values)
+
+    # We test absolute because PCA methods don't always give the same sign, and can flip.
+    assert np.absolute(actual_components[0]) == pytest.approx(np.absolute(expected_pca["comps"][0]))
+    assert np.absolute(actual_components[1]) == pytest.approx(np.absolute(expected_pca["comps"][1]))
+
+    assert np.absolute(actual_means) == pytest.approx(np.absolute(expected_pca["center"]))
+
+@pytest.mark.skip
+def test_scale_projected_data():
+    raise


### PR DESCRIPTION
This was missing for awhile, and making me feel a bit anxious. Not we have unit tests to confirm that PCA methods generate the same output as the polismath output (for centers and components/eigenvectors).

I've also added agora.run_clustering tests, as we want to ensure this never breaks while working on utils.