### PR TITLE
Add `polis_id` argument to replace separate `report_id` and `conversation_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changes
 - Fixed participant projections to map more closely to Polis with `utils.pca.sparsity_aware_project_ptpt()`.
 - Add simple Polis implementation in `reddwarf.implementations.polis`.
+- Add singular `polis_id` arg as recommended way to download (auto-detect `report_id` vs `converation_id`).
 
 ### Chores
 - Moved agora implementation from `reddwarf.agora` to `reddwarf.implementations.agora` (deprecation warning).

--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ from reddwarf.polis import PolisClient
 # If you only know the conversation ID, you can fetch the live data from the Polis APIs.
 # Note that this may be fresher than a static export hosted elsewhere.
 client = PolisClient()
-client.load_data(conversation_id="4yy3sh84js")
-# If you happen to know the report ID, that can be used instead.
+client.load_data(polis_id="4yy3sh84js")
+# If you happen to know the report ID, that can be used instead:
+#
+#     client.load_data(polis_id="r5jsvucnwuuhw7dzjvaim")
 
-# All of these are equivalent:
+# All of these are equivalent to the above-mentioned:
 client.load_data(conversation_id="4yy3sh84js")
 client.load_data(conversation_id="4yy3sh84js", data_source="api")
 client.load_data(report_id="r5jsvucnwuuhw7dzjvaim")
@@ -74,10 +76,10 @@ client.load_data(report_id="r5jsvucnwuuhw7dzjvaim", data_source="api")
 # If you know the report ID, you can also download from the newer and more official CSV export API endpoint:
 # Example: https://pol.is/api/v3/reportExport/r5jsvucnwuuhw7dzjvaim/participant-votes.csv
 client = PolisClient()
-client.load_data(report_id="r5jsvucnwuuhw7dzjvaim", data_source="csv_export")
+client.load_data(polis_id="r5jsvucnwuuhw7dzjvaim", data_source="csv_export")
 
 # All of these are equivalent:
-client.load_data(report_id="r5jsvucnwuuhw7dzjvaim", data_source="csv_export")
+client.load_data(polis_id="r5jsvucnwuuhw7dzjvaim", data_source="csv_export")
 client.load_data(directory_url="https://pol.is/api/v3/reportExport/r5jsvucnwuuhw7dzjvaim/")
 
 

--- a/docs/notebooks/dump-downloaded-polis-data.ipynb
+++ b/docs/notebooks/dump-downloaded-polis-data.ipynb
@@ -72,7 +72,7 @@
         "\n",
         "# Topic: What were the most significant developments in tech and politics in 2018?\n",
         "# 5 groups, 65 ptpts (56 grouped), 43 comments (open)\n",
-        "loader = Loader(report_id=\"r2dfw8eambusb8buvecjt\")\n",
+        "loader = Loader(polis_id=\"r2dfw8eambusb8buvecjt\")\n",
         "loader.dump_data(output_dir=f\"{root_path}/{output_subdir}\")"
       ]
     }

--- a/docs/notebooks/dup-votes.ipynb
+++ b/docs/notebooks/dup-votes.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "client = PolisClient(is_strict_moderation=False)\n",
     "# Load data with duplicate votes.\n",
-    "client.load_data(report_id=report_id, data_source=\"csv_export\")"
+    "client.load_data(polis_id=report_id, data_source=\"csv_export\")"
    ]
   }
  ],

--- a/docs/notebooks/example-usage.ipynb
+++ b/docs/notebooks/example-usage.ipynb
@@ -92,7 +92,7 @@
     "from reddwarf.data_presenter import DataPresenter\n",
     "\n",
     "client = PolisClient()\n",
-    "client.load_data(report_id=\"r8xhmkwp6shm9yfermteh\")\n",
+    "client.load_data(polis_id=\"r8xhmkwp6shm9yfermteh\")\n",
     "# Generate the raw vote matrix\n",
     "client.get_matrix(is_filtered=True)\n",
     "client.run_pca()\n",

--- a/docs/notebooks/heatmap.ipynb
+++ b/docs/notebooks/heatmap.ipynb
@@ -92,7 +92,7 @@
     "from reddwarf.data_presenter import DataPresenter\n",
     "\n",
     "client = PolisClient()\n",
-    "client.load_data(report_id=CONVOS[\"tech-politics-2018\"][\"report_id\"])\n",
+    "client.load_data(polis_id=CONVOS[\"tech-politics-2018\"][\"report_id\"])\n",
     "\n",
     "# matrix_raw = client.get_matrix(is_filtered=False)\n",
     "\n",

--- a/docs/notebooks/map-xids.ipynb
+++ b/docs/notebooks/map-xids.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "client = PolisClient()\n",
     "CONVO_ID_WITH_XIDS=\"4kjz5rrrfe\"\n",
-    "client.load_data(conversation_id=CONVO_ID_WITH_XIDS)\n",
+    "client.load_data(polis_id=CONVO_ID_WITH_XIDS)\n",
     "known_xids = [12334552, 12334553, 12334554, \"foobar\"]\n",
     "mappings = client.data_loader.fetch_xid_to_pid_mappings(known_xids)\n",
     "for xid, pid in mappings.items():\n",

--- a/docs/notebooks/polis-implementation-demo.ipynb
+++ b/docs/notebooks/polis-implementation-demo.ipynb
@@ -100,7 +100,7 @@
         "\n",
         "# We'll use the old class-based client to simple load vote data.\n",
         "client = PolisClient()\n",
-        "client.load_data(report_id=REPORT_ID)\n",
+        "client.load_data(polis_id=REPORT_ID)\n",
         "votes = client.data_loader.votes_data\n",
         "\n",
         "# Show what our raw vote data looks like:\n",

--- a/docs/notebooks/strip-pass-votes.ipynb
+++ b/docs/notebooks/strip-pass-votes.ipynb
@@ -167,7 +167,7 @@
     "# To see the consequences of not having pass/neutral/zero votes\n",
     "def cluster_and_plot(do_strip_pass_votes, dummy_var):\n",
     "    client = PolisClient()\n",
-    "    client.load_data(report_id=report_id)\n",
+    "    client.load_data(polis_id=report_id)\n",
     "    if do_strip_pass_votes:\n",
     "        client.votes = []\n",
     "        client.load_votes_data(data=[v for v in client.data_loader.votes_data if v[\"vote\"] != 0])\n",

--- a/reddwarf/data_loader.py
+++ b/reddwarf/data_loader.py
@@ -11,8 +11,9 @@ from reddwarf.helpers import CachedLimiterSession, CloudflareBypassHTTPAdapter
 ua = UserAgent()
 
 class Loader():
-    def __init__(self, filepaths=[], conversation_id=None, report_id=None, is_cache_enabled=True, output_dir=None, data_source="api", directory_url=None):
+    def __init__(self, filepaths=[], polis_id=None, conversation_id=None, report_id=None, is_cache_enabled=True, output_dir=None, data_source="api", directory_url=None):
         self.polis_instance_url = "https://pol.is"
+        self.polis_id = report_id or conversation_id or polis_id
         self.conversation_id = conversation_id
         self.report_id = report_id
         self.is_cache_enabled = is_cache_enabled
@@ -28,7 +29,8 @@ class Loader():
 
         if self.filepaths:
             self.load_file_data()
-        elif self.conversation_id or self.report_id or self.directory_url:
+        elif self.conversation_id or self.report_id or self.polis_id or self.directory_url:
+            self.populate_polis_ids()
             self.init_http_client()
             if self.directory_url:
                 self.data_source = "csv_export"
@@ -42,6 +44,17 @@ class Loader():
 
         if self.output_dir:
             self.dump_data(self.output_dir)
+
+    def populate_polis_ids(self):
+        if self.polis_id:
+            # If polis_id set, set report or conversation ID.
+            if self.polis_id[0] == "r":
+                self.report_id = self.polis_id
+            elif self.polis_id[0].isdigit():
+                self.conversation_id = self.polis_id
+        else:
+            # If not set, write it from what's provided.
+            self.polis_id = self.report_id or self.conversation_id
 
     def dump_data(self, output_dir):
         if not os.path.exists(output_dir):

--- a/reddwarf/polis.py
+++ b/reddwarf/polis.py
@@ -211,9 +211,9 @@ class PolisClient():
         self.optimal_silhouette = silhouette_score
         self.optimal_cluster_labels = cluster_labels
 
-    def load_data(self, filepaths=[], conversation_id=None, report_id=None, directory_url=None, data_source="api"):
-        if conversation_id or report_id or filepaths or directory_url:
-            self.data_loader = Loader(conversation_id=conversation_id, report_id=report_id, filepaths=filepaths, directory_url=directory_url, data_source=data_source)
+    def load_data(self, filepaths=[], polis_id=None, conversation_id=None, report_id=None, directory_url=None, data_source="api"):
+        if conversation_id or report_id or polis_id or filepaths or directory_url:
+            self.data_loader = Loader(conversation_id=conversation_id, report_id=report_id, polis_id=polis_id, filepaths=filepaths, directory_url=directory_url, data_source=data_source)
 
             # Infer moderation type from API conversation_data when available.
             if self.data_loader.conversation_data:

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -77,6 +77,26 @@ def test_load_data_from_api_and_dump_files(tmp_path):
     assert comments_path.exists() == True
     assert math_path.exists() == True
 
+def test_load_data_via_polis_id_report_id():
+    report_id = SMALL_CONVO_REPORT_ID
+    loader = Loader(polis_id=report_id)
+
+    assert loader.polis_id == report_id
+    # Auto-populated from report_id API call.
+    assert loader.conversation_id != None
+    assert loader.report_id == report_id
+    assert len(loader.report_data) > 0
+
+def test_load_data_via_polis_id_convo_id():
+    convo_id = SMALL_CONVO_ID
+    loader = Loader(polis_id=convo_id)
+
+    assert loader.polis_id == convo_id
+    assert loader.conversation_id == convo_id
+    # Can't get report_id from convo_id
+    assert loader.report_id == None
+    assert len(loader.votes_data) > 0
+
 def test_load_data_from_api_report():
     loader = Loader(report_id=SMALL_CONVO_REPORT_ID)
     assert len(loader.report_data) > 0

--- a/tests/test_polis.py
+++ b/tests/test_polis.py
@@ -137,7 +137,24 @@ def test_infer_moderation_type_from_file(polis_convo_data):
 
 def test_load_data_from_report_id():
     client = PolisClient()
+
+    assert client.data_loader == None
     client.load_data(report_id="r5hr48j8y8mpcffk7crmk")
+    assert client.data_loader != None
+
+def test_load_data_from_convo_id():
+    client = PolisClient()
+
+    assert client.data_loader == None
+    client.load_data(conversation_id="9knpdktubt")
+    assert client.data_loader != None
+
+def test_load_data_from_polis_id():
+    client = PolisClient()
+
+    assert client.data_loader == None
+    client.load_data(polis_id="9knpdktubt")
+    assert client.data_loader != None
 
 def test_matrix_cutoff_timestamp():
     client = PolisClient()


### PR DESCRIPTION
Currently, `reddwarf.data_loader.Loader()` (and therefore `reddwarf.polis.load_data()`) can take an argument like `report_id` or `conversation_id` to initiate loading data from polis.

Sincer conversation IDs always start with a digit, and report IDs always start with "r", we can instead just pass in a `polis_id` argument, and have the loader determine what it's looking at.

## Todos
- [x] add extra `polis_id` arg to `Loader()`
- [x] add extra `polis_id` arg to `PolisClient.load_data()`
- [x] add unit tests
- [x] update README
- [x] update example notebooks