### PR TITLE
Add export functionality for creating CSV from Polis API data (aka only public conversation ID, not report ID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This is the generalized pipeline of Polis-like processes that we're aiming to ac
 - Install python (preferrably virtual environment)
 - Install uv (python package manager) (e.g. `pip install uv`)
 - Install dependencies with `make install` (or `make install-dev`)
-- Check other 'make' commands from the root Makefile (e.g. `make test` to run tests)
+- Run `make` command alone to see other helpful make subcommands
 - Alternatively, run one of the ipynb notebooks; possibly replacing the install command at the top with `%pip install -e ../../` to use the local source instead.
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ This is the generalized pipeline of Polis-like processes that we're aiming to ac
 
 ## Get Involved
 
+### Running it for local development
+
+- Install python (preferrably virtual environment)
+- Install uv (python package manager) (e.g. `pip install uv`)
+- Install dependencies with `make install` (or `make install-dev`)
+- Check other 'make' commands from the root Makefile (e.g. `make test` to run tests)
+- Alternatively, run one of the ipynb notebooks; possibly replacing the install command at the top with `%pip install -e ../../` to use the local source instead.
+
+### Contributing
+
 - [Join][pug-discord] the _Polis User Group (PUG)_ **Discord** server.
 - Open a **GitHub issue**.
 - Submit a **GitHub pull request**.

--- a/reddwarf/data_loader.py
+++ b/reddwarf/data_loader.py
@@ -60,29 +60,6 @@ class Loader():
             # If not set, write it from what's provided.
             self.polis_id = self.report_id or self.conversation_id
 
-    class ReportType(Enum):
-        SUMMARY = "summary"
-        VOTES = "votes"
-        COMMENTS = "comments"
-        PARTICIPANT_VOTES = "participant-votes"
-        COMMENT_GROUPS = "comment-groups"
-
-    def fetch_csv(self, type: ReportType, output_dir=None):
-        if not output_dir:
-            if self.output_dir:
-                output_dir = self.output_dir
-            else:
-                raise ValueError("output_dir must be set in either the loader or as parameter to this function")
-
-        print(f"Downloading CSVs from remote server to {output_dir}")
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
-
-        with open(f"{output_dir}/{self.report_id}_{type.value}.csv", 'w') as f:
-            r = self.session.get(f"{self.polis_instance_url}/api/v3/reportExport/{self.report_id}/{type.value}.csv")
-            f.write(r.text)
-        return f
-
     # Deprecated.
     def dump_data(self, output_dir):
         self.export_data(output_dir, format="json")

--- a/reddwarf/data_loader.py
+++ b/reddwarf/data_loader.py
@@ -67,7 +67,13 @@ class Loader():
         PARTICIPANT_VOTES = "participant-votes"
         COMMENT_GROUPS = "comment-groups"
 
-    def fetch_csv(self, output_dir, type: ReportType):
+    def fetch_csv(self, type: ReportType, output_dir=None):
+        if not output_dir:
+            if self.output_dir:
+                output_dir = self.output_dir
+            else:
+                raise ValueError("output_dir must be set in either the loader or as parameter to this function")
+        
         print(f"Downloading CSVs from remote server to {output_dir}")
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)

--- a/reddwarf/data_loader.py
+++ b/reddwarf/data_loader.py
@@ -512,27 +512,27 @@ class Loader():
             else:
                 raise ValueError("Unknown file type")
 
-    def load_file_data_votes(self, file=None):
+    def load_file_data_votes(self, file):
         with open(file) as f:
             votes_data = json.load(f)
 
         votes_data = [Vote(**vote).model_dump(mode='json') for vote in votes_data]
         self.votes_data = votes_data
 
-    def load_file_data_comments(self, file=None):
+    def load_file_data_comments(self, file):
         with open(file) as f:
             comments_data = json.load(f)
 
         comments_data = [Statement(**c).model_dump(mode='json') for c in comments_data]
         self.comments_data = comments_data
 
-    def load_file_data_conversation(self, file=None):
+    def load_file_data_conversation(self, file):
         with open(file) as f:
             convo_data = json.load(f)
 
         self.conversation_data = convo_data
 
-    def load_file_data_math(self, file=None):
+    def load_file_data_math(self, file):
         with open(file) as f:
             math_data = json.load(f)
 
@@ -597,7 +597,7 @@ class Loader():
         for item in self.votes_data:
             item["vote"] = -item["vote"]
 
-    def load_api_data_votes(self, last_participant_id=None):
+    def load_api_data_votes(self, last_participant_id=0):
         for pid in range(0, last_participant_id+1):
             params = {
                 "pid": pid,

--- a/reddwarf/data_loader.py
+++ b/reddwarf/data_loader.py
@@ -502,27 +502,27 @@ class Loader():
             else:
                 raise ValueError("Unknown file type")
 
-    def load_file_data_votes(self, file):
+    def load_file_data_votes(self, file=None):
         with open(file) as f:
             votes_data = json.load(f)
 
         votes_data = [Vote(**vote).model_dump(mode='json') for vote in votes_data]
         self.votes_data = votes_data
 
-    def load_file_data_comments(self, file):
+    def load_file_data_comments(self, file=None):
         with open(file) as f:
             comments_data = json.load(f)
 
         comments_data = [Statement(**c).model_dump(mode='json') for c in comments_data]
         self.comments_data = comments_data
 
-    def load_file_data_conversation(self, file):
+    def load_file_data_conversation(self, file=None):
         with open(file) as f:
             convo_data = json.load(f)
 
         self.conversation_data = convo_data
 
-    def load_file_data_math(self, file):
+    def load_file_data_math(self, file=None):
         with open(file) as f:
             math_data = json.load(f)
 
@@ -587,7 +587,7 @@ class Loader():
         for item in self.votes_data:
             item["vote"] = -item["vote"]
 
-    def load_api_data_votes(self, last_participant_id=0):
+    def load_api_data_votes(self, last_participant_id=None):
         for pid in range(0, last_participant_id+1):
             params = {
                 "pid": pid,

--- a/reddwarf/data_loader.py
+++ b/reddwarf/data_loader.py
@@ -3,7 +3,7 @@ import json
 import os
 from typing import Literal
 from fake_useragent import UserAgent
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone, timedelta
 from requests_ratelimiter import SQLiteBucket, LimiterSession
 import csv
 from io import StringIO

--- a/reddwarf/data_loader.py
+++ b/reddwarf/data_loader.py
@@ -1,7 +1,6 @@
 from enum import Enum
 import json
 import os
-from typing import Literal
 from fake_useragent import UserAgent
 from datetime import datetime, timezone, timedelta
 from requests_ratelimiter import SQLiteBucket, LimiterSession

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -255,3 +255,4 @@ def test_export_data_csv(tmp_path):
                 assert len(loader.votes_data) == len(actual_lines)-1 # -1 for header
             elif type == helpers.ReportType.PARTICIPANT_VOTES:
                 assert len(loader.math_data["user-vote-counts"]) == len(actual_lines)-1 # -1 for header
+    assert False

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -255,4 +255,3 @@ def test_export_data_csv(tmp_path):
                 assert len(loader.votes_data) == len(actual_lines)-1 # -1 for header
             elif type == helpers.ReportType.PARTICIPANT_VOTES:
                 assert len(loader.math_data["user-vote-counts"]) == len(actual_lines)-1 # -1 for header
-    assert False

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -224,7 +224,7 @@ def test_export_polis_format(tmp_path):
         
     for type in loader.ReportType:
         # first, dowload the original for comparison:
-        downloaded = loader.fetch_csv(output_dir, type)
+        downloaded = loader.fetch_csv(type, output_dir)
         
         with (
             open(downloaded.name) as f_expected,

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,8 +1,4 @@
-from enum import Enum
-import filecmp
-import os
 import pytest
-from requests import session
 from reddwarf.data_loader import Loader
 
 from tests import helpers

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,7 +1,11 @@
+from enum import Enum
 import filecmp
+import os
 import pytest
+from requests import session
 from reddwarf.data_loader import Loader
 
+from tests import helpers
 from tests.fixtures import polis_convo_data
 
 # 3 groups, 28 ptpts (24 grouped), 63 statements.
@@ -222,9 +226,9 @@ def test_export_data_csv(tmp_path):
     loader.export_data(output_dir, format="csv")
     # ... and compare them to the original CSVs:
 
-    for type in loader.ReportType:
+    for type in helpers.ReportType:
         # first, dowload the original for comparison:
-        downloaded = loader.fetch_csv(type, output_dir)
+        downloaded = helpers.fetch_csv(type, output_dir, report_id)
 
         with (
             open(downloaded.name) as f_expected,
@@ -245,9 +249,9 @@ def test_export_data_csv(tmp_path):
             #  * the originals' data seems less accurate than ours, so lines won't match
 
             # Compare with our own data instead:
-            if type == loader.ReportType.COMMENTS or type == loader.ReportType.COMMENT_GROUPS:
+            if type == helpers.ReportType.COMMENTS or type == helpers.ReportType.COMMENT_GROUPS:
                 assert len(loader.comments_data) == len(actual_lines)-1 # -1 for header
-            elif type == loader.ReportType.VOTES:
+            elif type == helpers.ReportType.VOTES:
                 assert len(loader.votes_data) == len(actual_lines)-1 # -1 for header
-            elif type == loader.ReportType.PARTICIPANT_VOTES:
+            elif type == helpers.ReportType.PARTICIPANT_VOTES:
                 assert len(loader.math_data["user-vote-counts"]) == len(actual_lines)-1 # -1 for header


### PR DESCRIPTION
Added export functionality to export in polis-style .csv files (see https://github.com/polis-community/red-dwarf/issues/65)

Call loader.export_polis_format() with an optional output_dir param (if output_dir was already specified in loader init; otherwise it's required). 

Additionally I added a loader.fetch_csv() method, which downloads the specified CSV from polis with their v3 reportExport api. 

A basic test is added as well.