### PR TITLE
Only run CI on mainline branch pushes (and PRs)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: "Run Tests"
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We are doubling up all the tests on feature branches. We only need the pull_request trigger to fire, not the push trigger.

Too much CI:

<img width="829" alt="Screenshot 2025-07-09 at 11 24 11 PM" src="https://github.com/user-attachments/assets/5e3cb4c7-44ec-4244-9022-1af83e05e2eb" />
