### PR TITLE
When using a remote fixture, use the in-conv math_data key

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -101,7 +101,7 @@ def polis_convo_data(request):
                 math_data=loader.math_data,
                 data_dir=tmpdirname,
                 filename=filename,
-                keep_participant_ids=keep_participant_ids,
+                keep_participant_ids=loader.math_data["in-conv"],
             )
             # Tmpdir cleanup will happen after yield completes
             return

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,14 @@
+import pytest
+from tests.fixtures import polis_convo_data
+
+from tests.test_data_loader import SMALL_CONVO_ID, SMALL_CONVO_REPORT_ID
+
+@pytest.mark.parametrize("polis_convo_data", [SMALL_CONVO_REPORT_ID], indirect=True)
+def test_loading_remote_fixture_from_report_id(polis_convo_data):
+    # TODO: Confirm that length is longer than get_clusterable_participant_ids list.
+    assert len(polis_convo_data.keep_participant_ids) > 0
+
+@pytest.mark.parametrize("polis_convo_data", [SMALL_CONVO_ID], indirect=True)
+def test_loading_remote_fixture_from_convo_id(polis_convo_data):
+    # TODO: Confirm that length is longer than get_clusterable_participant_ids list.
+    assert len(polis_convo_data.keep_participant_ids) > 0


### PR DESCRIPTION
This was an oversight, as the fixture should have included this by default. the `in-conv` key is a list of all the pid for participants that are in the conversation, so it should force the recalculated polis data to include these participant IDs (even if they don't meet the thresholds). This helps align our local tests with what we see in polis API, because Polis platform has some bespoke rules to keep some participants in the convo who would otherwise be filtered out.