### PR TITLE
feat: re-add Agora as recommended pipeline, fix Polis repness bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,23 @@
 
 ## [Unreleased][] (YYYY-MM-DD)
 
+### Changes
+
+- Re-add Agora implementation with statistical improvements over Polis.
+  - Benjamini-Hochberg FDR control for statement selection (replaces heuristic `pick_max`).
+  - Simes' p-value combination for repness (valid under positive dependence between probability and representativeness tests).
+  - Effective agreement GAC: `prod(pa*(1-pd))^(1/n)` penalizes divided groups (replaces raw `prod(pa)^(1/n)`).
+  - Zero-vote filter: excludes statements with no votes from BH hypothesis count.
+  - Shared `apply_bh_with_vote_filter()` helper for modular BH computation.
+- Add `agora-demo.ipynb` notebook as recommended quickstart.
+- Document Agora implementation in API reference.
+- Position Agora as the recommended default pipeline in README.
+
 ### Chores
 
 - Add CLAUDE.md for Claude Code guidance. ([#115][])
+- Add cram snapshot tests for Agora pipeline output.
+- Add Polis vs Agora selection comparison to cram snapshot.
 
    [#115]: https://github.com/polis-community/red-dwarf/pull/115
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,13 @@ test-debug: ## Run tests via pytest, optionally filtering (with verbose debuggin
 	# Show full diffs on failure.
 	$(UV_RUN) pytest -p no:nbmake --capture=no -vv -k '$(TEST_FILTER)'
 
-test-all: test test-nb docs-build ## Run unit and notebook tests
+test-cram: ## Run cram snapshot tests
+	$(UV_RUN) cram tests/cram/*.t
+
+test-cram-update: ## Update cram snapshot tests (interactive)
+	$(UV_RUN) cram -i tests/cram/*.t
+
+test-all: test test-nb test-cram docs-build ## Run unit, notebook, and cram tests
 
 # Small hint to remove gitignore'd python version file, which can confuse usage of uv.
 clean:

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ A <em>DIM</em>ensional <em>RED</em>uction library for reproducing and experiment
 ## Features
 
 - Loads data from any Polis conversation on any Polis server, using only the conversation URL.
-- Reproduces Polis calculation pipeline from only raw vote data.
-  - "Classic" Polis pipeline = PCA dimensional reduction, KMeans clustering, and comment statistics.
+- Two pipeline implementations:
+  - **"Polis" pipeline** = Reproduces the stock Polis calculation pipeline exactly. PCA, KMeans, heuristic statement selection.
+  - **"Agora" pipeline** = Improved statement selection via [Benjamini-Hochberg][bh-wiki] FDR control, effective agreement group-aware consensus, and [Simes'][simes-wiki] p-value combination.
 - Alternative algorithms, aspiring for sensible defaults:
   - dimensional reduction: [PaCMAP & LocalMAP][pacmap]
     - Planned: [UMAP][umap], [TriMap][trimap], [PHATE][], [ivis][ivis], [LargeVis][largevis]
@@ -28,6 +29,23 @@ A <em>DIM</em>ensional <em>RED</em>uction library for reproducing and experiment
     - Planned: [EVOC][evoc]
 - Helpful visualizations via `matplotlib`
   - Planned: [Plotly][plotly]
+
+## Polis vs Agora
+
+Both pipelines share the same core (PCA + KMeans by default). The difference is in **statement selection** and **consensus scoring**:
+
+| Feature | Polis | Agora |
+|---------|-------|-------|
+| **Statement selection** | Heuristic `pick_max=5` per group | Benjamini-Hochberg FDR control (adaptive, data-driven) |
+| **P-value combination** | z-score thresholds | Simes' method (valid under positive dependence) |
+| **Group-aware consensus** | `prod(pa)^(1/n)` (raw agreement) | `prod(pa*(1-pd))^(1/n)` (penalizes divided groups) |
+| **Zero-vote handling** | Included in hypothesis testing | Excluded from BH hypothesis count |
+| **Output** | Only top-N selected statements | ALL statements ranked with selection flags |
+
+- **Polis**: Always matches upstream Polis behavior. Good for verification and comparison.
+- **Agora** _(recommended)_: Adds statistical rigor and fixes known issues. Recommended for production use.
+
+Agora roadmap: cleaner input/output APIs, improved default algorithms, reduced DataFrame complexity, and richer outputs.
 
 ## Goals
 
@@ -44,10 +62,10 @@ For now, see [this related issue](https://github.com/patcon/red-dwarf/issues/4)
 ## Sponsors
 
 <p>
-  <a href="https://agoracitizen.network" rel="noopener sponsored" target="_blank"><img width="167" src="https://agoracitizen.network/images/big_logo_agora.png" alt="Agora Citizen Network" title="Where citizens converge to exchange and debate ideas" loading="lazy" /></a>
+  <a href="https://www.agoracitizen.network" rel="noopener sponsored" target="_blank"><img width="167" src="https://www.agoracitizen.network/images/big_logo_agora.png" alt="Agora Citizen Network" title="Where citizens converge to exchange and debate ideas" loading="lazy" /></a>
 </p>
 
-Red Dwarf is generously sponsored by [ZKorum SAS](https://zkorum.com), creators of the [Agora Citizen Network](https://agoracitizen.network).
+Red Dwarf is generously sponsored by [ZKorum SAS](https://zkorum.com), creators of the [Agora Citizen Network](https://www.agoracitizen.network).
 
 Are you or your organization eager to see more platforms and community built around democracy-supporting algorithms like these? **Please consider [getting in touch on Discord](#get-involved) and supporting our continued work!** (ping @patcon)
 
@@ -71,16 +89,18 @@ pip install red-dwarf[all]
 # pip install red-dwarf[alt-algos,plots]
 ```
 
-See [`docs/notebooks/polis-implementation-demo.ipynb`][notebook] or [`docs/notebooks/`][notebooks] for other examples.
+See [`docs/notebooks/agora-demo.ipynb`][agora-notebook] for the recommended quickstart using the Agora pipeline.
 
+For reproducing stock Polis results exactly, see [`docs/notebooks/polis-implementation-demo.ipynb`][polis-notebook].
 
 | screenshot of library-generated notebook | screenshot of Polis-generated report |
 |---|---|
-| [![screen of the sample jupyter notebook](docs/notebook-screenshot.png)][notebook] | ![screenshot of the polis report](https://imgur.com/blkIEtW.png) |
+| [![screen of the sample jupyter notebook](docs/notebook-screenshot.png)][polis-notebook] | ![screenshot of the polis report](https://imgur.com/blkIEtW.png) |
 
+- [`docs/notebooks/agora-demo.ipynb`](https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/agora-demo.ipynb) — Agora pipeline quickstart _(recommended)_
+- [`docs/notebooks/polis-implementation-demo.ipynb`](https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/polis-implementation-demo.ipynb) — Classic Polis pipeline baseline
 - [`docs/notebooks/loading-data.ipynb`](https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/loading-data.ipynb)
 - [`docs/notebooks/heatmap.ipynb`](https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/heatmap.ipynb)
-- [`docs/notebooks/polis-implementation-demo.ipynb`](https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/polis-implementation-demo.ipynb)
 - [`docs/notebooks/dump-downloaded-polis-data.ipynb`](https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/dump-downloaded-polis-data.ipynb)
 - Advanced
    - [`docs/notebooks/map-xids.ipynb`](https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/map-xids.ipynb)
@@ -125,6 +145,9 @@ See [`CHANGELOG.md`][changelog].
    [pypi]: https://pypi.org/project/red-dwarf/
    [stellarpunk]: https://www.youtube.com/watch?v=opnkQVZrhAw
 
+   [bh-wiki]: https://en.wikipedia.org/wiki/False_discovery_rate#Benjamini%E2%80%93Hochberg_procedure
+   [simes-wiki]: https://en.wikipedia.org/wiki/Simes%27_test
+
    [pacmap]: https://github.com/YingfanWang/PaCMAP
    [umap]: https://github.com/lmcinnes/umap
    [trimap]: https://github.com/eamid/trimap
@@ -137,10 +160,11 @@ See [`CHANGELOG.md`][changelog].
 
    [plotly]: https://plotly.com/python/
 
-   [notebook]: https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/polis-implementation-demo.ipynb
+   [agora-notebook]: https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/agora-demo.ipynb
+   [polis-notebook]: https://github.com/polis-community/red-dwarf/blob/main/docs/notebooks/polis-implementation-demo.ipynb
    [notebooks]: https://github.com/polis-community/red-dwarf/tree/main/docs/notebooks/
    [ZKorum]: https://github.com/zkorum
-   [agora]: https://agoracitizen.network/
+   [agora]: https://www.agoracitizen.network/
    [ngi-funding]: https://trustchain.ngi.eu/zkorum/
    [MPLv2]: https://choosealicense.com/licenses/mpl-2.0/
    [license]: https://github.com/polis-community/red-dwarf/blob/main/LICENSE

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -2,7 +2,21 @@
 
 ## `reddwarf.implementations.base`
 
-### ::: reddwarf.implementations.polis.run_pipeline
+### ::: reddwarf.implementations.base.run_pipeline
+    options:
+        show_root_heading: true
+
+## `reddwarf.implementations.agora`
+
+### ::: reddwarf.implementations.agora.run_pipeline
+    options:
+        show_root_heading: true
+
+### ::: reddwarf.implementations.agora.AgoraClusteringResult
+    options:
+        show_root_heading: true
+
+### ::: reddwarf.implementations.agora.compute_effective_agreement_gac
     options:
         show_root_heading: true
 
@@ -74,9 +88,21 @@ use in Scikit-Learn workflows, pipelines, and APIs.
     options:
         show_root_heading: true
 
+### ::: reddwarf.utils.consensus.rank_consensus_statements
+    options:
+        show_root_heading: true
+
 ## `reddwarf.utils.stats`
 
 ### ::: reddwarf.utils.stats.select_representative_statements
+    options:
+        show_root_heading: true
+
+### ::: reddwarf.utils.stats.rank_representative_statements
+    options:
+        show_root_heading: true
+
+### ::: reddwarf.utils.stats.apply_bh_with_vote_filter
     options:
         show_root_heading: true
 
@@ -127,3 +153,14 @@ use in Scikit-Learn workflows, pipelines, and APIs.
     options:
         show_root_heading: true
 
+### ::: reddwarf.types.agora.RankedRepnessStatement
+    options:
+        show_root_heading: true
+
+### ::: reddwarf.types.agora.RankedConsensusStatement
+    options:
+        show_root_heading: true
+
+### ::: reddwarf.types.agora.RankedConsensusResult
+    options:
+        show_root_heading: true

--- a/docs/notebooks/agora-demo.ipynb
+++ b/docs/notebooks/agora-demo.ipynb
@@ -1,0 +1,315 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/polis-community/red-dwarf/blob/main/docs/notebooks/agora-demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet red-dwarf[all]@git+https://github.com/polis-community/red-dwarf.git@main"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Agora Pipeline Demo\n",
+    "\n",
+    "This notebook demonstrates the **Agora pipeline**, the recommended default for Red Dwarf.\n",
+    "\n",
+    "Agora builds on the same core as Polis (PCA + KMeans) but improves statement selection and consensus scoring:\n",
+    "\n",
+    "- **Benjamini-Hochberg FDR control** for adaptive, data-driven statement selection (replaces Polis's heuristic `pick_max=5`)\n",
+    "- **Simes' p-value combination** for repness (valid under positive dependence)\n",
+    "- **Effective agreement GAC**: `prod(pa*(1-pd))^(1/n)` penalizes divided groups\n",
+    "- **Zero-vote filtering** to avoid inflating hypothesis counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data\n",
+    "\n",
+    "We use a local fixture with <100 participants from a real Polis conversation about tech and politics in 2018."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from reddwarf.data_loader import Loader\n",
+    "from reddwarf.utils.statements import process_statements\n",
+    "\n",
+    "# You can also load from a Polis URL: Loader(polis_id=\"r2dfw8eambusb8buvecjt\")\n",
+    "loader = Loader(filepaths=[\n",
+    "    \"../../tests/fixtures/below-100-ptpts/votes.json\",\n",
+    "    \"../../tests/fixtures/below-100-ptpts/comments.json\",\n",
+    "    \"../../tests/fixtures/below-100-ptpts/conversation.json\",\n",
+    "])\n",
+    "\n",
+    "_, _, mod_out_statement_ids, meta_statement_ids = process_statements(\n",
+    "    statement_data=loader.comments_data\n",
+    ")\n",
+    "\n",
+    "# Build a lookup for statement text\n",
+    "stmt_text = {}\n",
+    "for c in loader.comments_data:\n",
+    "    sid = c.get(\"tid\", c.get(\"statement_id\"))\n",
+    "    stmt_text[sid] = c.get(\"txt\", \"\")\n",
+    "\n",
+    "print(f\"Loaded {len(loader.votes_data)} votes\")\n",
+    "print(f\"Statements: {len(loader.comments_data)} total, {len(mod_out_statement_ids)} moderated out\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the Agora Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from reddwarf.implementations.agora import run_pipeline\n",
+    "\n",
+    "result = run_pipeline(\n",
+    "    votes=loader.votes_data,\n",
+    "    mod_out_statement_ids=mod_out_statement_ids,\n",
+    "    meta_statement_ids=meta_statement_ids,\n",
+    "    random_state=42,\n",
+    ")\n",
+    "\n",
+    "n_groups = len(result.ranked_repness)\n",
+    "n_clustered = len(result.participants_df[result.participants_df[\"to_cluster\"]])\n",
+    "n_statements = len(result.statements_df)\n",
+    "\n",
+    "print(f\"Participants: {n_clustered} clustered into {n_groups} groups\")\n",
+    "print(f\"Statements: {n_statements - len(mod_out_statement_ids)} active ({len(mod_out_statement_ids)} moderated out)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Representative Statements (Repness)\n",
+    "\n",
+    "For each group, statements are ranked by **effect size** (`ra * pa` for agree, `rd * pd` for disagree) and selected using Benjamini-Hochberg FDR control.\n",
+    "\n",
+    "The `[*]` marker indicates BH-selected statements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def truncate(text, max_len=60):\n",
+    "    if len(text) <= max_len:\n",
+    "        return text\n",
+    "    return text[:max_len] + \"...\"\n",
+    "\n",
+    "for gid in sorted(result.ranked_repness.keys()):\n",
+    "    print(f\"\\n--- Group {gid} ---\")\n",
+    "    print(f\"{'#':>2}  Sel  Dir       Effect  Statement\")\n",
+    "    for s in result.ranked_repness[gid]:\n",
+    "        sel = \"[*]\" if s.selected else \"[ ]\"\n",
+    "        direction = \"agree\" if s.repful_for == \"agree\" else \"disagree\"\n",
+    "        text = truncate(stmt_text.get(s.statement_id, \"?\"))\n",
+    "        print(f\"{s.rank:>2}  {sel}  {direction:<8}  {s.effect_size:.4f}  s{s.statement_id}: {text}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cross-Group Comparison\n",
+    "\n",
+    "The `group_comment_stats` DataFrame lets you compare how different groups responded to each statement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group_ids = sorted(result.ranked_repness.keys())\n",
+    "stats = result.group_comment_stats\n",
+    "\n",
+    "# Show top repness statement for group 0 across all groups\n",
+    "top_stmt = result.ranked_repness[0][0]\n",
+    "sid = top_stmt.statement_id\n",
+    "print(f\"Statement s{sid}: {truncate(stmt_text.get(sid, '?'))}\")\n",
+    "print(f\"Direction: {top_stmt.repful_for}, Effect size: {top_stmt.effect_size:.4f}\")\n",
+    "print()\n",
+    "for g in group_ids:\n",
+    "    row = stats.loc[(g, sid)]\n",
+    "    print(f\"  Group {g}: pa={row['pa']:.2f}, pd={row['pd']:.2f} (agree={int(row['na'])}, disagree={int(row['nd'])}, seen={int(row['ns'])})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Group-Aware Consensus (GAC)\n",
+    "\n",
+    "Agora uses **effective agreement**: `prod(pa * (1-pd))^(1/n_groups)`.\n",
+    "\n",
+    "Unlike raw Polis GAC (`prod(pa)^(1/n)`), this penalizes groups that are genuinely divided (high agree AND high disagree)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gac = result.group_aware_consensus\n",
+    "\n",
+    "# Top statements by effective agreement (agree direction)\n",
+    "sorted_agree = sorted(\n",
+    "    [(sid, score) for sid, score in gac[\"agree\"].items() if sid not in mod_out_statement_ids],\n",
+    "    key=lambda x: x[1], reverse=True,\n",
+    ")\n",
+    "\n",
+    "print(\"Top 10 statements by group-aware consensus (agree):\")\n",
+    "print(f\"{'#':>2}  Stmt  GAC     Text\")\n",
+    "for rank, (sid, score) in enumerate(sorted_agree[:10], 1):\n",
+    "    text = truncate(stmt_text.get(sid, \"?\"))\n",
+    "    print(f\"{rank:>2}  s{sid:<3}  {score:.4f}  {text}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Consensus Statements\n",
+    "\n",
+    "Consensus statements use BH FDR control on the one-prop test z-scores, ranked by pa (agree) or pd (disagree)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"--- Consensus (agree) ---\")\n",
+    "print(f\"{'#':>2}  Sel  Stmt  Effect  p_adj    Text\")\n",
+    "for s in result.ranked_consensus.agree:\n",
+    "    sel = \"[*]\" if s.selected else \"[ ]\"\n",
+    "    text = truncate(stmt_text.get(s.statement_id, \"?\"))\n",
+    "    print(f\"{s.rank:>2}  {sel}  s{s.statement_id:<3}  {s.effect_size:.4f}  {s.adjusted_p_value:.4f}  {text}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"--- Consensus (disagree) ---\")\n",
+    "print(f\"{'#':>2}  Sel  Stmt  Effect  p_adj    Text\")\n",
+    "for s in result.ranked_consensus.disagree:\n",
+    "    sel = \"[*]\" if s.selected else \"[ ]\"\n",
+    "    text = truncate(stmt_text.get(s.statement_id, \"?\"))\n",
+    "    print(f\"{s.rank:>2}  {sel}  s{s.statement_id:<3}  {s.effect_size:.4f}  {s.adjusted_p_value:.4f}  {text}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison with Polis Selection\n",
+    "\n",
+    "For reference, here's what stock Polis selection (`pick_max=5`) produces on the same data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from reddwarf.utils.stats import select_representative_statements\n",
+    "from reddwarf.utils.consensus import select_consensus_statements\n",
+    "\n",
+    "polis_repness = select_representative_statements(\n",
+    "    grouped_stats_df=result.group_comment_stats,\n",
+    "    mod_out_statement_ids=mod_out_statement_ids,\n",
+    ")\n",
+    "polis_consensus = select_consensus_statements(\n",
+    "    vote_matrix=result.raw_vote_matrix,\n",
+    "    mod_out_statement_ids=mod_out_statement_ids,\n",
+    ")\n",
+    "\n",
+    "def fmt_stmt(sid, direction):\n",
+    "    d = \"a\" if direction == \"agree\" else \"d\"\n",
+    "    return f\"s{sid}({d})\"\n",
+    "\n",
+    "print(\"--- Repness comparison ---\")\n",
+    "for gid in sorted(result.ranked_repness.keys()):\n",
+    "    polis_stmts = [fmt_stmt(s[\"tid\"], s[\"repful-for\"]) for s in polis_repness.get(gid, [])]\n",
+    "    agora_stmts = [fmt_stmt(s.statement_id, s.repful_for) for s in result.ranked_repness[gid] if s.selected]\n",
+    "    print(f\"Group {gid}:\")\n",
+    "    print(f\"  Polis (pick_max=5): {' '.join(polis_stmts) if polis_stmts else '(none)'}\")\n",
+    "    print(f\"  Agora (BH fdr=0.10): {' '.join(agora_stmts) if agora_stmts else '(none)'}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"--- Consensus comparison ---\")\n",
+    "polis_agree = [f\"s{s['tid']}\" for s in polis_consensus[\"agree\"]]\n",
+    "agora_agree = [f\"s{s.statement_id}\" for s in result.ranked_consensus.agree if s.selected]\n",
+    "print(f\"Agree:\")\n",
+    "print(f\"  Polis: {' '.join(polis_agree) if polis_agree else '(none)'}\")\n",
+    "print(f\"  Agora: {' '.join(agora_agree) if agora_agree else '(none)'}\")\n",
+    "\n",
+    "polis_disagree = [f\"s{s['tid']}\" for s in polis_consensus[\"disagree\"]]\n",
+    "agora_disagree = [f\"s{s.statement_id}\" for s in result.ranked_consensus.disagree if s.selected]\n",
+    "print(f\"Disagree:\")\n",
+    "print(f\"  Polis: {' '.join(polis_disagree) if polis_disagree else '(none)'}\")\n",
+    "print(f\"  Agora: {' '.join(agora_disagree) if agora_disagree else '(none)'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Key Differences Summary\n",
+    "\n",
+    "| Feature | Polis | Agora |\n",
+    "|---------|-------|-------|\n",
+    "| **Statement selection** | Heuristic `pick_max=5` per group | BH FDR control (adaptive, data-driven) |\n",
+    "| **P-value combination** | z-score thresholds | Simes' method (valid under positive dependence) |\n",
+    "| **Group-aware consensus** | `prod(pa)^(1/n)` (raw agreement) | `prod(pa*(1-pd))^(1/n)` (penalizes divided groups) |\n",
+    "| **Zero-vote handling** | Included in hypothesis testing | Excluded from BH hypothesis count |\n",
+    "| **Output** | Only top-N selected statements | ALL statements ranked with selection flags |\n",
+    "\n",
+    "**Use Agora** for production analysis — it provides statistically rigorous, adaptive selection.\n",
+    "\n",
+    "**Use Polis** when you need to exactly reproduce upstream Polis behavior for verification or comparison."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requests-cache = { git = "https://github.com/requests-cache/requests-cache", rev
 
 [project.optional-dependencies]
 alt-algos = [
-    "pacmap>=0.7.0",
+    "pacmap>=0.9.1",
 
     # Use older numba on macOS Intel (avoids build issues)
     # See: https://github.com/numba/llvmlite/issues/1389#issuecomment-3763361889
@@ -54,6 +54,7 @@ all = [
 ]
 dev = [
     "coverage>=6.0",
+    "cram>=0.7",
     "ipywidgets>=8.0.0",
     "mkdocs-same-dir>=0.1.3",
     "mkdocstrings-python>=1.8.0",
@@ -64,7 +65,7 @@ dev = [
 
 [dependency-groups]
 alt-algos = [
-    "pacmap>=0.7.0",
+    "pacmap>=0.9.1",
     "hdbscan>=0.8.40",
 ]
 plots = [
@@ -78,6 +79,7 @@ all = [
 ]
 dev = [
     "coverage>=6.0",
+    "cram>=0.7",
     "ipywidgets>=8.0.0",
     "mkdocs-same-dir>=0.1.3",
     "mkdocstrings-python>=1.8.0",

--- a/reddwarf/implementations/agora.py
+++ b/reddwarf/implementations/agora.py
@@ -1,0 +1,134 @@
+from typing import Optional
+from dataclasses import dataclass
+import pandas as pd
+from pandas import DataFrame
+
+from reddwarf.implementations import base
+from reddwarf.types.agora import RankedRepnessStatement, RankedConsensusResult
+from reddwarf.utils.consensus import rank_consensus_statements
+from reddwarf.utils.reducer.base import ReducerModel
+from reddwarf.utils.clusterer.base import ClustererModel
+from reddwarf.utils.stats import rank_representative_statements
+
+
+@dataclass
+class AgoraClusteringResult:
+    """
+    Attributes:
+        raw_vote_matrix (DataFrame): Raw sparse vote matrix before any processing.
+        filtered_vote_matrix (DataFrame): Raw sparse vote matrix with moderated statements zero'd out.
+        reducer (ReducerModel): scikit-learn reducer model fitted to vote matrix.
+        clusterer (ClustererModel): scikit-learn clusterer model, fitted to participant projections.
+        group_comment_stats (DataFrame): A multi-index dataframe for each statement, indexed by group ID and statement.
+        statements_df (DataFrame): A dataframe with all intermediary and final statement data/calculations/metadata.
+        participants_df (DataFrame): A dataframe with all intermediary and final participant data/calculations/metadata.
+        participant_projections (dict): A dict of participant projected coordinates, keyed to participant ID.
+        statement_projections (Optional[dict]): A dict of statement projected coordinates, keyed to statement ID.
+        group_aware_consensus (dict): A nested dict of statement group-aware-consensus values.
+        ranked_repness (dict[int, list[RankedRepnessStatement]]): All statements per group, ranked by effect size with BH selection.
+        ranked_consensus (RankedConsensusResult): All statements ranked for consensus, with BH selection.
+    """
+
+    raw_vote_matrix: DataFrame
+    filtered_vote_matrix: DataFrame
+    reducer: ReducerModel
+    clusterer: ClustererModel | None
+    group_comment_stats: DataFrame
+    statements_df: DataFrame
+    participants_df: DataFrame
+    participant_projections: dict
+    statement_projections: Optional[dict]
+    group_aware_consensus: dict
+    ranked_repness: dict[int, list[RankedRepnessStatement]]
+    ranked_consensus: RankedConsensusResult
+
+
+def compute_effective_agreement_gac(
+    grouped_stats_df: pd.DataFrame,
+    statement_ids,
+    n_groups: int,
+) -> dict:
+    """Compute GAC using effective agreement: prod(pa * (1-pd))^(1/n_groups).
+
+    Unlike the Polis formula (raw pa product), this penalizes groups that are
+    genuinely divided (high agree AND high disagree) by discounting each group's
+    agreement by its disagreement.
+
+    Args:
+        grouped_stats_df: MultiIndex DataFrame with (group_id, statement_id) index, containing 'pa' and 'pd' columns.
+        statement_ids: Statement IDs to compute GAC for.
+        n_groups: Number of groups.
+
+    Returns:
+        Dict with 'agree' and 'disagree' keys, each mapping statement_id to GAC score.
+    """
+    agree = {}
+    disagree = {}
+    for sid in statement_ids:
+        ea_prod = 1.0
+        ed_prod = 1.0
+        for gid in range(n_groups):
+            pa = grouped_stats_df.loc[(gid, sid), "pa"]
+            pd_val = grouped_stats_df.loc[(gid, sid), "pd"]
+            ea_prod *= pa * (1 - pd_val)
+            ed_prod *= pd_val * (1 - pa)
+        agree[sid] = ea_prod ** (1.0 / n_groups)
+        disagree[sid] = ed_prod ** (1.0 / n_groups)
+    return {"agree": agree, "disagree": disagree}
+
+
+def run_pipeline(
+    fdr_rate: float = 0.10,
+    **kwargs,
+) -> AgoraClusteringResult:
+    """
+    Agora clustering pipeline. Runs the base pipeline and adds ranked
+    representative/consensus statements with Benjamini-Hochberg selection.
+
+    Accepts all the same arguments as base.run_pipeline(), plus:
+
+    Args:
+        fdr_rate (float): False discovery rate for Benjamini-Hochberg selection.
+        **kwargs: All arguments forwarded to base.run_pipeline().
+
+    Returns:
+        AgoraClusteringResult: Clustering results with ranked statement outputs.
+    """
+    base_result = base.run_pipeline(**kwargs)
+
+    ranked_repness = rank_representative_statements(
+        grouped_stats_df=base_result.group_comment_stats,
+        mod_out_statement_ids=kwargs.get("mod_out_statement_ids", []),
+        fdr_rate=fdr_rate,
+    )
+
+    ranked_consensus = rank_consensus_statements(
+        vote_matrix=base_result.raw_vote_matrix,
+        mod_out_statement_ids=kwargs.get("mod_out_statement_ids", []),
+        fdr_rate=fdr_rate,
+    )
+
+    # Recompute GAC with effective agreement (agora improvement over Polis raw pa).
+    n_groups = len(
+        base_result.group_comment_stats.index.get_level_values("group_id").unique()
+    )
+    group_aware_consensus = compute_effective_agreement_gac(
+        base_result.group_comment_stats,
+        base_result.statements_df.index,
+        n_groups,
+    )
+
+    return AgoraClusteringResult(
+        raw_vote_matrix=base_result.raw_vote_matrix,
+        filtered_vote_matrix=base_result.filtered_vote_matrix,
+        reducer=base_result.reducer,
+        clusterer=base_result.clusterer,
+        group_comment_stats=base_result.group_comment_stats,
+        statements_df=base_result.statements_df,
+        participants_df=base_result.participants_df,
+        participant_projections=base_result.participant_projections,
+        statement_projections=base_result.statement_projections,
+        group_aware_consensus=group_aware_consensus,
+        ranked_repness=ranked_repness,
+        ranked_consensus=ranked_consensus,
+    )

--- a/reddwarf/types/agora.py
+++ b/reddwarf/types/agora.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class RankedRepnessStatement:
+    statement_id: int
+    repful_for: Literal["agree", "disagree"]
+    na: int
+    nd: int
+    ns: int
+    pa: float
+    pd: float
+    pat: float
+    pdt: float
+    ra: float
+    rd: float
+    rat: float
+    rdt: float
+    effect_size: float  # ra*pa or rd*pd depending on direction
+    p_value: float  # combined p-value (before BH)
+    adjusted_p_value: float  # after BH
+    selected: bool  # passes BH cutoff
+    rank: int  # 1-based, by effect_size descending
+
+
+@dataclass
+class RankedConsensusStatement:
+    statement_id: int
+    direction: Literal["agree", "disagree"]
+    na: int
+    nd: int
+    ns: int
+    pa: float
+    pd: float
+    pat: float
+    pdt: float
+    effect_size: float  # pa or pd
+    p_value: float
+    adjusted_p_value: float
+    selected: bool
+    rank: int  # 1-based, by effect_size descending
+
+
+@dataclass
+class RankedConsensusResult:
+    agree: list[RankedConsensusStatement]
+    disagree: list[RankedConsensusStatement]

--- a/reddwarf/utils/consensus.py
+++ b/reddwarf/utils/consensus.py
@@ -102,6 +102,8 @@ def select_consensus_statements(
     df["consensus_agree_rank"] = agree_candidates["consensus_agree_rank"]
     df["consensus_disagree_rank"] = disagree_candidates["consensus_disagree_rank"]
 
+    format_comments = lambda row: format_comment_stats(row, confidence)
+
     # Select top N agree/disagree statements
     if agree_candidates.empty:
         top_agree = []
@@ -112,7 +114,7 @@ def select_consensus_statements(
             for st in agree_candidates.sort_values("consensus_agree_rank")
             .head(pick_max)
             .reset_index()
-            .apply(format_comment_stats, axis=1)
+            .apply(format_comments, axis=1)
         ]
 
     if disagree_candidates.empty:
@@ -124,7 +126,7 @@ def select_consensus_statements(
             for st in disagree_candidates.sort_values("consensus_disagree_rank")
             .head(pick_max)
             .reset_index()
-            .apply(format_comment_stats, axis=1)
+            .apply(format_comments, axis=1)
         ]
 
     return {

--- a/reddwarf/utils/consensus.py
+++ b/reddwarf/utils/consensus.py
@@ -1,11 +1,16 @@
+import numpy as np
 import pandas as pd
 from typing import List, TypedDict
 from reddwarf.utils.matrix import VoteMatrix
+from reddwarf.types.agora import RankedConsensusStatement, RankedConsensusResult
 from reddwarf.utils.stats import (
+    apply_bh_with_vote_filter,
+    benjamini_hochberg,
     calculate_comment_statistics,
     format_comment_stats,
     is_significant,
     votes,
+    z_to_pvalue,
 )
 
 
@@ -102,8 +107,6 @@ def select_consensus_statements(
     df["consensus_agree_rank"] = agree_candidates["consensus_agree_rank"]
     df["consensus_disagree_rank"] = disagree_candidates["consensus_disagree_rank"]
 
-    format_comments = lambda row: format_comment_stats(row, confidence)
-
     # Select top N agree/disagree statements
     if agree_candidates.empty:
         top_agree = []
@@ -114,7 +117,7 @@ def select_consensus_statements(
             for st in agree_candidates.sort_values("consensus_agree_rank")
             .head(pick_max)
             .reset_index()
-            .apply(format_comments, axis=1)
+            .apply(format_comment_stats, axis=1)
         ]
 
     if disagree_candidates.empty:
@@ -126,10 +129,97 @@ def select_consensus_statements(
             for st in disagree_candidates.sort_values("consensus_disagree_rank")
             .head(pick_max)
             .reset_index()
-            .apply(format_comments, axis=1)
+            .apply(format_comment_stats, axis=1)
         ]
 
     return {
         "agree": top_agree,
         "disagree": top_disagree,
     }
+
+
+def rank_consensus_statements(
+    vote_matrix: VoteMatrix,
+    mod_out_statement_ids: list[int] = [],
+    fdr_rate: float = 0.10,
+) -> RankedConsensusResult:
+    """
+    Ranks ALL statements by consensus strength and marks selections via Benjamini-Hochberg.
+
+    Args:
+        vote_matrix (VoteMatrix): The full raw vote matrix.
+        mod_out_statement_ids (list[int]): Statements to ignore.
+        fdr_rate (float): False discovery rate for BH procedure.
+
+    Returns:
+        RankedConsensusResult with agree and disagree lists, each containing all statements
+        ranked by effect size (pa or pd) with BH selection flags.
+    """
+    N_g_c, N_v_g_c, P_v_g_c, _, P_v_g_c_test, *_ = calculate_comment_statistics(
+        vote_matrix=vote_matrix,
+        cluster_labels=None,
+    )
+    MOCK_GID = 0
+    df = pd.DataFrame(
+        {
+            "na": N_v_g_c[votes.A, MOCK_GID, :],
+            "nd": N_v_g_c[votes.D, MOCK_GID, :],
+            "ns": N_g_c[MOCK_GID, :],
+            "pa": P_v_g_c[votes.A, MOCK_GID, :],
+            "pd": P_v_g_c[votes.D, MOCK_GID, :],
+            "pat": P_v_g_c_test[votes.A, MOCK_GID, :],
+            "pdt": P_v_g_c_test[votes.D, MOCK_GID, :],
+        },
+        index=vote_matrix.columns,
+    )
+
+    if mod_out_statement_ids:
+        df = df[~df.index.isin(mod_out_statement_ids)]
+
+    def _rank_direction(
+        df: pd.DataFrame,
+        z_col: str,
+        effect_col: str,
+        direction: str,
+    ) -> list[RankedConsensusStatement]:
+        p_values = z_to_pvalue(df[z_col].values)
+        effect_sizes = df[effect_col].values
+
+        has_votes = (df["na"].values > 0) | (df["nd"].values > 0)
+        selected_mask, adjusted = apply_bh_with_vote_filter(
+            np.asarray(p_values), has_votes, fdr_rate
+        )
+
+        # Rank by effect size descending.
+        n = len(effect_sizes)
+        rank_order = np.argsort(-effect_sizes)
+        ranks = np.empty(n, dtype=int)
+        ranks[rank_order] = np.arange(1, n + 1)
+
+        statements: list[RankedConsensusStatement] = []
+        for idx in rank_order:
+            row = df.iloc[idx]
+            statements.append(
+                RankedConsensusStatement(
+                    statement_id=int(df.index[idx]),
+                    direction=direction,
+                    na=int(row["na"]),
+                    nd=int(row["nd"]),
+                    ns=int(row["ns"]),
+                    pa=float(row["pa"]),
+                    pd=float(row["pd"]),
+                    pat=float(row["pat"]),
+                    pdt=float(row["pdt"]),
+                    effect_size=float(effect_sizes[idx]),
+                    p_value=float(p_values[idx]),
+                    adjusted_p_value=float(adjusted[idx]),
+                    selected=bool(selected_mask[idx]),
+                    rank=int(ranks[idx]),
+                )
+            )
+        return statements
+
+    agree_ranked = _rank_direction(df, "pat", "pa", "agree")
+    disagree_ranked = _rank_direction(df, "pdt", "pd", "disagree")
+
+    return RankedConsensusResult(agree=agree_ranked, disagree=disagree_ranked)

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -68,7 +68,7 @@ def two_prop_test(
 def is_significant(z_val: float, confidence: float = 0.90) -> bool:
     """Test whether z-statistic is significant at 90% confidence (one-tailed, right-side)."""
     critical_value = norm.ppf(confidence)  # 90% confidence level, one-tailed
-    return z_val > critical_value
+    return abs(z_val) > critical_value  # rat/rdt can be negative
 
 
 def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
@@ -88,7 +88,9 @@ def get_statement_significant_for(
     pat: float, rat: float, pdt: float, rdt: float
 ) -> Literal["agree", "disagree"]:
     "Get if statement is significant for agree or disagree"
-    is_repful_for_agree = pat + rat >= pdt + rdt
+    is_repful_for_agree = abs(pat) + abs(rat) >= abs(pdt) + abs(
+        rdt
+    )  # rat/rdt can be negative, probably not the case for pat/pdt
     is_repful = "agree" if is_repful_for_agree else "disagree"
     return is_repful
 

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -88,8 +88,8 @@ def get_statement_significant_for(
     pat: float, rat: float, pdt: float, rdt: float
 ) -> Literal["agree", "disagree"]:
     "Get if statement is significant for agree or disagree"
-    is_repful_for_agree = abs(pat) + abs(rat) >= abs(pdt) + abs(
-        rdt
+    is_repful_for_agree = abs(pat) >= abs(
+        pdt
     )  # rat/rdt can be negative, probably not the case for pat/pdt
     is_repful = "agree" if is_repful_for_agree else "disagree"
     return is_repful

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -88,10 +88,10 @@ def get_statement_significant_for(
     pat: float, rat: float, pdt: float, rdt: float
 ) -> Literal["agree", "disagree"]:
     "Get if statement is significant for agree or disagree"
-    is_repful_for_agree = pat > pdt
-    # rat/rdt can be negative, probably not the case for pat/pdt
-    is_repful = "agree" if is_repful_for_agree else "disagree"
-    return is_repful
+    # is_repful_for_agree = pat > pdt
+    # # rat/rdt can be negative, probably not the case for pat/pdt
+    # is_repful = "agree" if is_repful_for_agree else "disagree"
+    return "agree"  # testing
 
 
 def beats_best_by_repness_test(

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -105,7 +105,7 @@ def get_statement_repful_for(
     format_style = "group-repness" if has_repness else "consensus"
 
     if format_style == "consensus":
-        pat, pdt = [row[col] for col in ["rat", "rdt"]]
+        pat, pdt = [row[col] for col in ["pat", "pdt"]]
         is_repful_for_agree = pat > pdt
         repful_for = "agree" if is_repful_for_agree else "disagree"
         return repful_for
@@ -116,7 +116,10 @@ def get_statement_repful_for(
     if is_statement_disagree_significant(row, confidence):
         return "disagree"
     # This should not happen if it is called when the statement has already been identified as significant...
-    rat, rdt = [row[col] for col in ["rat", "rdt"]]
+    rat, rdt, statement_id = [row[col] for col in ["rat", "rdt", "statement_id"]]
+    print(
+        f"Warning: using a different method to calculate repful_for for statement_id={statement_id} "
+    )
     is_repful_for_agree = rat > rdt
     repful_for = "agree" if is_repful_for_agree else "disagree"
     return repful_for

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -92,7 +92,7 @@ def is_statement_disagree_significant(row: pd.Series, confidence=0.90) -> bool:
 def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
     # Require at least some agree or disagree votes (not just passes)
-    if row["na"] == 0 and row["nd"] == 0
+    if row["na"] == 0 and row["nd"] == 0:
         return False
     is_agreement_significant = is_statement_agree_significant(row, confidence)
     is_disagreement_significant = is_statement_disagree_significant(row, confidence)

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -1,3 +1,4 @@
+from os import stat
 import pandas as pd
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -111,15 +112,27 @@ def get_statement_repful_for(
         return repful_for
 
     # now rat and rdt exist
+    is_agree_sig = False
+    is_disagree_sig = False
     if is_statement_agree_significant(row, confidence):
-        return "agree"
+        is_agree_sig = True
     if is_statement_disagree_significant(row, confidence):
+        is_disagree_sig = True
+    if is_agree_sig and not is_disagree_sig:
+        return "agree"
+    if is_disagree_sig and not is_agree_sig:
         return "disagree"
-    # This should not happen if it is called when the statement has already been identified as significant...
+
     rat, rdt, statement_id = [row[col] for col in ["rat", "rdt", "statement_id"]]
-    print(
-        f"Warning: using a different method to calculate repful_for for statement_id={statement_id} "
-    )
+    if is_disagree_sig and is_agree_sig:
+        print(
+            f"Warning: both agree and disagree significant at the same time for statement_id={statement_id}"
+        )
+    else:
+        # This should not happen if it is called when the statement has already been identified as significant...
+        print(
+            f"Warning: using a different method to calculate repful_for for statement_id={statement_id} "
+        )
     is_repful_for_agree = rat > rdt
     repful_for = "agree" if is_repful_for_agree else "disagree"
     return repful_for

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -91,6 +91,9 @@ def is_statement_disagree_significant(row: pd.Series, confidence=0.90) -> bool:
 
 def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
+    # Require at least some agree or disagree votes (not just passes)
+    if row["na"] == 0 and row["nd"] == 0
+        return False
     is_agreement_significant = is_statement_agree_significant(row, confidence)
     is_disagreement_significant = is_statement_disagree_significant(row, confidence)
 

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -612,45 +612,13 @@ def select_representative_statements(
         sig_filter = lambda row: is_statement_significant(row, actual_confidence)
         sufficient_statements_row_mask = group_df.apply(sig_filter, axis="columns")
         sufficient_statements = group_df[sufficient_statements_row_mask]
-        sufficient_statements = (
-            pd.DataFrame(
-                [
-                    format_comment_stats(row, actual_confidence)
-                    for _, row in sufficient_statements.iterrows()
-                ]
-            )
-            # Create a column to sort repnress, then remove.
-            .assign(repness_metric=repness_metric)
-            .sort_values(by="repness_metric", ascending=False)
-            .drop(columns="repness_metric")
-        )
 
-        selected = [row.to_dict() for _, row in sufficient_statements.iterrows()]
-        while len(sufficient_statements) < pick_max and actual_confidence - 0.05 >= 0.6:
+        while len(sufficient_statements) == 0 and actual_confidence >= 0.65:
             # lower confidence until finding statments
             actual_confidence = actual_confidence - 0.05
-            sig_filter_updated = lambda row: is_statement_significant(
-                row, actual_confidence
-            )
-            sufficient_statements_row_mask = group_df.apply(
-                sig_filter_updated, axis="columns"
-            )
-            sufficient_statements_to_add = group_df[sufficient_statements_row_mask]
-            sufficient_statements_to_add = (
-                pd.DataFrame(
-                    [
-                        format_comment_stats(row, actual_confidence)
-                        for _, row in sufficient_statements_to_add.iterrows()
-                    ]
-                )
-                # Create a column to sort repnress, then remove.
-                .assign(repness_metric=repness_metric)
-                .sort_values(by="repness_metric", ascending=False)
-                .drop(columns="repness_metric")
-            )
-            selected = selected + [
-                row.to_dict() for _, row in sufficient_statements_to_add.iterrows()
-            ]
+            sig_filter = lambda row: is_statement_significant(row, actual_confidence)
+            sufficient_statements_row_mask = group_df.apply(sig_filter, axis="columns")
+            sufficient_statements = group_df[sufficient_statements_row_mask]
 
         # Finalize statements into output format.
         # TODO: Figure out how to finalize only at end in output. Change repness_metric?
@@ -662,10 +630,23 @@ def select_representative_statements(
                 if beats_best_by_repness_test(row, best_overall):
                     best_overall = row
             selected = [best_overall]
-
-        selected = selected[:pick_max]
-        # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
-        selected = sorted(selected, key=lambda row: row["repful-for"])
+        else:
+            sufficient_statements = (
+                pd.DataFrame(
+                    [
+                        format_comment_stats(row, actual_confidence)
+                        for _, row in sufficient_statements.iterrows()
+                    ]
+                )
+                # Create a column to sort repnress, then remove.
+                .assign(repness_metric=repness_metric)
+                .sort_values(by="repness_metric", ascending=False)
+                .drop(columns="repness_metric")
+            )
+            selected = [row.to_dict() for _, row in sufficient_statements.iterrows()]
+            selected = selected[:pick_max]
+            # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
+            selected = sorted(selected, key=lambda row: row["repful-for"])
 
         repness[gid] = selected
 

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -1,4 +1,3 @@
-from os import stat
 import pandas as pd
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -69,15 +68,12 @@ def two_prop_test(
 def is_significant(z_val: float, confidence: float = 0.90) -> bool:
     """Test whether z-statistic is significant at 90% confidence (one-tailed, right-side)."""
     critical_value = norm.ppf(confidence)  # 90% confidence level, one-tailed
-    return z_val > critical_value
+    return z_val > critical_value  # rat/rdt can be negative
 
 
 def is_statement_agree_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
-    pat, rat, na, nd = [row[col] for col in ["pat", "rat", "na", "nd"]]
-    # Explicitly don't allow something that hasn't been voted on at all
-    if na == 0 and nd == 0:
-        return False
+    pat, rat = [row[col] for col in ["pat", "rat"]]
     is_agreement_significant = is_significant(pat, confidence) and is_significant(
         rat, confidence
     )
@@ -86,10 +82,7 @@ def is_statement_agree_significant(row: pd.Series, confidence=0.90) -> bool:
 
 def is_statement_disagree_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
-    pdt, rdt, na, nd = [row[col] for col in ["pdt", "rdt", "na", "nd"]]
-    # Explicitly don't allow something that hasn't been voted on at all
-    if na == 0 and nd == 0:
-        return False
+    pdt, rdt = [row[col] for col in ["pdt", "rdt"]]
     is_disagreement_significant = is_significant(pdt, confidence) and is_significant(
         rdt, confidence
     )
@@ -118,27 +111,15 @@ def get_statement_repful_for(
         return repful_for
 
     # now rat and rdt exist
-    is_agree_sig = False
-    is_disagree_sig = False
     if is_statement_agree_significant(row, confidence):
-        is_agree_sig = True
-    if is_statement_disagree_significant(row, confidence):
-        is_disagree_sig = True
-    if is_agree_sig and not is_disagree_sig:
         return "agree"
-    if is_disagree_sig and not is_agree_sig:
+    if is_statement_disagree_significant(row, confidence):
         return "disagree"
-
+    # This should not happen if it is called when the statement has already been identified as significant...
     rat, rdt, statement_id = [row[col] for col in ["rat", "rdt", "statement_id"]]
-    if is_disagree_sig and is_agree_sig:
-        print(
-            f"Warning: both agree and disagree significant at the same time for statement_id={statement_id}"
-        )
-    else:
-        # This should not happen if it is called when the statement has already been identified as significant...
-        print(
-            f"Warning: using a different method to calculate repful_for for statement_id={statement_id} "
-        )
+    print(
+        f"Warning: using a different method to calculate repful_for for statement_id={statement_id} "
+    )
     is_repful_for_agree = rat > rdt
     repful_for = "agree" if is_repful_for_agree else "disagree"
     return repful_for
@@ -634,13 +615,13 @@ def select_representative_statements(
         statements_by_confidence = {}
         statements_by_confidence[confidence] = sufficient_statements
         actual_confidence = confidence
-        if confidence > 0.7:
-            # keep decreasing by 0.05 until reaching 0.70
+        if confidence > 0.6:
+            # keep decreasing by 0.05 until reaching 0.60
             for decreased_confidence in [
                 round(x, 2)
                 for x in [
                     confidence - i * 0.05
-                    for i in range(int((confidence - 0.7) / 0.05) + 1)
+                    for i in range(int((confidence - 0.6) / 0.05) + 1)
                 ]
             ]:
                 sig_filter = lambda row: is_statement_significant(
@@ -653,17 +634,20 @@ def select_representative_statements(
                 statements_by_confidence[decreased_confidence] = (
                     sufficient_statements_test
                 )
-            # Step 1: Find all confidences that reach pick_max - 2
+            # Step 1: Find all confidences that reach pick_max
             candidates = [
-                c for c, s in statements_by_confidence.items() if len(s) >= pick_max - 2
+                c for c, s in statements_by_confidence.items() if len(s) == pick_max
             ]
 
             if candidates:
                 # If there are multiple, pick the highest confidence
                 best_confidence = max(candidates)
             else:
-                # Otherwise, pick the highest confidence
-                best_confidence = max(statements_by_confidence.items())
+                # Otherwise, pick the highest confidence with the largest list below pick_max
+                max_len = max(len(s) for s in statements_by_confidence.values())
+                best_confidence = max(
+                    c for c, s in statements_by_confidence.items() if len(s) == max_len
+                )
             sufficient_statements = statements_by_confidence[best_confidence]
             actual_confidence = best_confidence
 
@@ -694,11 +678,6 @@ def select_representative_statements(
             selected = selected[:pick_max]
             # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
             selected = sorted(selected, key=lambda row: row["repful-for"])
-
-        # TODO: improve best agree alg
-        if len(selected) > 0 and selected[0] is not None:
-            if selected[0]["repful-for"] == "agree":
-                selected[0]["best-agree"] = True
 
         repness[gid] = selected
 

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -657,13 +657,17 @@ def select_representative_statements(
         # Finalize statements into output format.
         # TODO: Figure out how to finalize only at end in output. Change repness_metric?
 
-        # most likely won't happen
+        # Fallback: no statements passed significance tests even at lowest confidence.
+        # Pick the single best statement by repness z-score, formatted properly.
         if len(sufficient_statements) == 0:
             best_overall = None
             for _, row in group_df.iterrows():
                 if beats_best_by_repness_test(row, best_overall):
                     best_overall = row
-            selected = [best_overall]
+            if best_overall is not None:
+                selected = [format_comment_stats(best_overall, actual_confidence)]
+            else:
+                selected = []
         else:
             sufficient_statements = (
                 pd.DataFrame(

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -9,6 +9,7 @@ from reddwarf.types.polis import (
     PolisRepness,
     PolisRepnessStatement,
 )
+from reddwarf.types.agora import RankedRepnessStatement
 from reddwarf.utils.reducer.pca import calculate_extremity
 
 
@@ -71,6 +72,75 @@ def is_significant(z_val: float, confidence: float = 0.90) -> bool:
     return z_val > critical_value  # rat/rdt can be negative
 
 
+def z_to_pvalue(z: ArrayLike) -> np.floating | NDArray[np.floating]:
+    """Convert one-tailed right-side z-scores to p-values."""
+    return 1 - norm.cdf(np.asarray(z))
+
+
+def benjamini_hochberg(p_values: NDArray, fdr_rate: float) -> NDArray[np.bool_]:
+    """Benjamini-Hochberg procedure for controlling false discovery rate.
+
+    Returns a boolean mask indicating which hypotheses are rejected (selected).
+    """
+    p_values = np.asarray(p_values, dtype=float)
+    n = len(p_values)
+    if n == 0:
+        return np.array([], dtype=bool)
+    sorted_indices = np.argsort(p_values)
+    sorted_p = p_values[sorted_indices]
+    thresholds = (np.arange(1, n + 1) / n) * fdr_rate
+    passing = sorted_p <= thresholds
+    if not passing.any():
+        return np.zeros(n, dtype=bool)
+    max_k = np.max(np.where(passing))
+    selected = np.zeros(n, dtype=bool)
+    selected[sorted_indices[: max_k + 1]] = True
+    return selected
+
+
+def apply_bh_with_vote_filter(
+    p_values: NDArray,
+    has_votes: NDArray[np.bool_],
+    fdr_rate: float,
+) -> tuple[NDArray[np.bool_], NDArray]:
+    """Apply BH selection only to testable statements (those with votes).
+
+    Statements without votes get selected=False and adjusted_p_value=1.0.
+    This avoids inflating the hypothesis count with noise from Laplace smoothing.
+
+    Args:
+        p_values: Raw p-values for all statements.
+        has_votes: Boolean mask — True if the statement has at least one vote.
+        fdr_rate: False discovery rate for BH procedure.
+
+    Returns:
+        Tuple of (selected_mask, adjusted_p_values) arrays for all statements.
+    """
+    n = len(p_values)
+    selected = np.zeros(n, dtype=bool)
+    adjusted = np.ones(n)
+
+    testable = np.where(has_votes)[0]
+    if len(testable) == 0:
+        return selected, adjusted
+
+    p_testable = p_values[testable]
+    selected[testable] = benjamini_hochberg(p_testable, fdr_rate)
+
+    # BH-adjusted p-values for testable statements.
+    m = len(p_testable)
+    sorted_idx = np.argsort(p_testable)
+    sorted_p = p_testable[sorted_idx]
+    raw_adj = sorted_p * m / np.arange(1, m + 1)
+    cummin = np.minimum.accumulate(raw_adj[::-1])[::-1]
+    adj_testable = np.minimum(cummin, 1.0)
+    reordered = np.empty(m)
+    reordered[sorted_idx] = adj_testable
+    adjusted[testable] = reordered
+
+    return selected, adjusted
+
+
 def is_statement_agree_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
     pat, rat = [row[col] for col in ["pat", "rat"]]
@@ -119,18 +189,21 @@ def get_statement_repful_for(
         return repful_for
 
     # now rat and rdt exist
-    if is_statement_agree_significant(row, confidence):
+    agree_sig = is_statement_agree_significant(row, confidence)
+    disagree_sig = is_statement_disagree_significant(row, confidence)
+
+    if agree_sig and disagree_sig:
+        # Both directions significant — pick the stronger one by combined z-score.
+        agree_strength = row["pat"] + row["rat"]
+        disagree_strength = row["pdt"] + row["rdt"]
+        return "agree" if agree_strength >= disagree_strength else "disagree"
+    if agree_sig:
         return "agree"
-    if is_statement_disagree_significant(row, confidence):
+    if disagree_sig:
         return "disagree"
-    # This should not happen if it is called when the statement has already been identified as significant...
-    rat, rdt, statement_id = [row[col] for col in ["rat", "rdt", "statement_id"]]
-    print(
-        f"Warning: using a different method to calculate repful_for for statement_id={statement_id} "
-    )
-    is_repful_for_agree = rat > rdt
-    repful_for = "agree" if is_repful_for_agree else "disagree"
-    return repful_for
+    # Fallback: neither significant — compare raw z-scores.
+    rat, rdt = row["rat"], row["rdt"]
+    return "agree" if rat > rdt else "disagree"
 
 
 def beats_best_by_repness_test(
@@ -343,29 +416,14 @@ def calculate_comment_statistics(
         )  # rdt
 
     # Calculate group-aware consensus
-    # Reference (original Polis): https://github.com/compdemocracy/polis/blob/edge/math/src/polismath/math/conversation.clj#L615-L636
-    #
-    # DIVERGENCE #1 FROM POLIS (geometric mean):
-    # Polis uses a raw product of per-group probabilities. This shrinks
-    # exponentially with more groups, making consensus scores unreachable
-    # for conversations with 4-6 opinion groups. We use a geometric mean
-    # (prod^(1/n_groups)) so that similar levels of cross-group consensus
-    # produce similar scores regardless of group count.
-    #
-    # DIVERGENCE #2 FROM POLIS (effective agreement):
-    # Polis uses raw p_agree per group, ignoring p_disagree entirely. This
-    # means a group that is genuinely divided (similar levels of agree and
-    # disagree) contributes the same score as an undivided group with the
-    # same agree level — allowing divided groups to be masked by other
-    # groups' strong agreement. We fix this by using "effective agreement":
-    # p_agree * (1 - p_disagree), which discounts each group's agreement
-    # by its disagreement so a divided group naturally drags down the
-    # consensus score.
+    # Geometric mean: normalize for group count so that similar levels of
+    # cross-group consensus produce similar scores regardless of whether
+    # the conversation has 2 or 6 opinion groups. This helps when applying
+    # a selection algorithm with a fixed threshold (e.g. 0.5).
+    # Reference: https://github.com/compdemocracy/polis/blob/edge/math/src/polismath/math/conversation.clj#L615-L636
     n_groups = P_v_g_c.shape[1]
-    effective_agree = P_v_g_c[votes.A, :, :] * (1 - P_v_g_c[votes.D, :, :])
-    effective_disagree = P_v_g_c[votes.D, :, :] * (1 - P_v_g_c[votes.A, :, :])
-    C_v_c[votes.A, :] = effective_agree.prod(axis=0) ** (1.0 / n_groups)
-    C_v_c[votes.D, :] = effective_disagree.prod(axis=0) ** (1.0 / n_groups)
+    C_v_c[votes.A, :] = P_v_g_c[votes.A, :, :].prod(axis=0) ** (1.0 / n_groups)
+    C_v_c[votes.D, :] = P_v_g_c[votes.D, :, :].prod(axis=0) ** (1.0 / n_groups)
 
     return (
         N_g_c,  # ns
@@ -378,10 +436,7 @@ def calculate_comment_statistics(
     )
 
 
-def format_comment_stats(
-    statement: pd.Series,
-    confidence: float = 0.90,
-) -> PolisRepnessStatement:
+def format_comment_stats(statement: pd.Series) -> PolisRepnessStatement:
     """
     Format internal statistics into concise agree/disagree format.
     Uses either consensus style or group-repness style depending on available fields.
@@ -412,9 +467,16 @@ def format_comment_stats(
     }
 
     # Select score source
-    repful_for = get_statement_repful_for(statement, confidence)
+    if format_style == "group-repness":
+        score_agree = float(statement["rat"])
+        score_disagree = float(statement["rdt"])
+    else:
+        score_agree = float(statement["pat"])
+        score_disagree = float(statement["pdt"])
 
-    fields = agree_fields if repful_for == "agree" else disagree_fields
+    use_agree = score_agree > score_disagree
+    fields = agree_fields if use_agree else disagree_fields
+    direction = "agree" if use_agree else "disagree"
 
     result = {
         "tid": int(statement["statement_id"]),
@@ -427,9 +489,9 @@ def format_comment_stats(
     if format_style == "group-repness":
         result["repness"] = float(statement[fields["repness"]])
         result["repness-test"] = float(statement[fields["repness-test"]])
-        result["repful-for"] = repful_for
+        result["repful-for"] = direction
     else:
-        result["cons-for"] = repful_for
+        result["cons-for"] = direction
 
     return result
 
@@ -510,7 +572,7 @@ def calculate_comment_statistics_dataframes(
         {
             "group-aware-consensus": C_v_c[votes.A, :],
             "group-aware-consensus-agree": C_v_c[votes.A, :],
-            "group-aware-consensus-disagree": C_v_c[votes.D, :],
+            "group-aware-consensus-disagree": C_v_c[votes.D, :]
         },
         index=vote_matrix.columns,
     )
@@ -601,13 +663,6 @@ def priority_metric(
 # Figuring out select-rep-comments flow
 # See: https://github.com/compdemocracy/polis/blob/7bf9eccc287586e51d96fdf519ae6da98e0f4a70/math/src/polismath/math/repness.clj#L209C7-L209C26
 # TODO: omg please clean this up.
-#
-# DIVERGENCE FROM POLIS: Polis uses a fixed confidence level and may return
-# fewer than pick_max statements when not enough pass the significance test.
-# We progressively lower the confidence from the initial value down to 0.60
-# (in 0.05 steps) to fill up to pick_max representative statements. If no
-# statements pass even the lowest confidence, we fall back to the single
-# best statement by repness z-score.
 def select_representative_statements(
     grouped_stats_df: pd.DataFrame,
     mod_out_statement_ids: list[int] = [],
@@ -616,6 +671,8 @@ def select_representative_statements(
 ) -> PolisRepness:
     """
     Selects statistically representative statements from each group cluster.
+
+    This is expected to match the Polis outputs when all defaults are set.
 
     Args:
         grouped_stats_df (pd.DataFrame): MultiIndex Dataframe of statement statistics, indexed by group and statement.
@@ -636,68 +693,29 @@ def select_representative_statements(
         # Bring statement_id into regular column.
         group_df = group_df.reset_index()
 
+        best_agree = None
+        # Track the best-agree, to bring to top if exists.
+        for _, row in group_df.iterrows():
+            if beats_best_of_agrees(row, best_agree, confidence):
+                best_agree = row
+
         sig_filter = lambda row: is_statement_significant(row, confidence)
         sufficient_statements_row_mask = group_df.apply(sig_filter, axis="columns")
         sufficient_statements = group_df[sufficient_statements_row_mask]
 
-        statements_by_confidence = {}
-        statements_by_confidence[confidence] = sufficient_statements
-        actual_confidence = confidence
-        if confidence > 0.6:
-            # keep decreasing by 0.05 until reaching 0.60
-            for decreased_confidence in [
-                round(x, 2)
-                for x in [
-                    confidence - i * 0.05
-                    for i in range(int((confidence - 0.6) / 0.05) + 1)
-                ]
-            ]:
-                sig_filter = lambda row: is_statement_significant(
-                    row, decreased_confidence
-                )
-                sufficient_statements_row_mask = group_df.apply(
-                    sig_filter, axis="columns"
-                )
-                sufficient_statements_test = group_df[sufficient_statements_row_mask]
-                statements_by_confidence[decreased_confidence] = (
-                    sufficient_statements_test
-                )
-            # Step 1: Find all confidences that reach pick_max
-            candidates = [
-                c for c, s in statements_by_confidence.items() if len(s) == pick_max
-            ]
-
-            if candidates:
-                # If there are multiple, pick the highest confidence
-                best_confidence = max(candidates)
-            else:
-                # Otherwise, pick the highest confidence with the largest list below pick_max
-                max_len = max(len(s) for s in statements_by_confidence.values())
-                best_confidence = max(
-                    c for c, s in statements_by_confidence.items() if len(s) == max_len
-                )
-            sufficient_statements = statements_by_confidence[best_confidence]
-            actual_confidence = best_confidence
-
-        # Finalize statements into output format.
-        # TODO: Figure out how to finalize only at end in output. Change repness_metric?
-
-        # Fallback: no statements passed significance tests even at lowest confidence.
-        # Pick the single best statement by repness z-score, formatted properly.
+        # Track the best, even if doesn't meet sufficient minimum, to have at least one.
+        best_overall = None
         if len(sufficient_statements) == 0:
-            best_overall = None
             for _, row in group_df.iterrows():
                 if beats_best_by_repness_test(row, best_overall):
                     best_overall = row
-            if best_overall is not None:
-                selected = [format_comment_stats(best_overall, actual_confidence)]
-            else:
-                selected = []
         else:
+            # Finalize statements into output format.
+            # TODO: Figure out how to finalize only at end in output. Change repness_metric?
             sufficient_statements = (
                 pd.DataFrame(
                     [
-                        format_comment_stats(row, actual_confidence)
+                        format_comment_stats(row)
                         for _, row in sufficient_statements.iterrows()
                     ]
                 )
@@ -706,14 +724,127 @@ def select_representative_statements(
                 .sort_values(by="repness_metric", ascending=False)
                 .drop(columns="repness_metric")
             )
-            selected = [row.to_dict() for _, row in sufficient_statements.iterrows()]
-            selected = selected[:pick_max]
-            # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
-            selected = sorted(selected, key=lambda row: row["repful-for"])
 
+        if best_agree is not None:
+            best_agree = format_comment_stats(best_agree)
+            best_agree.update({"n-agree": best_agree["n-success"], "best-agree": True})
+            best_head = [best_agree]
+        elif best_overall is not None:
+            best_overall = format_comment_stats(best_overall)
+            best_head = [best_overall]
+        else:
+            best_head = []
+
+        selected = best_head
+        selected = selected + [
+            row.to_dict()
+            for _, row in sufficient_statements.iterrows()
+            if best_head
+            # Skip any statements already in best_head
+            and best_head[0]["tid"] != row["tid"]
+        ]
+        selected = selected[:pick_max]
+        # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
+        selected = sorted(selected, key=lambda row: row["repful-for"])
         repness[gid] = selected
 
     return repness  # type:ignore
+
+
+def rank_representative_statements(
+    grouped_stats_df: pd.DataFrame,
+    mod_out_statement_ids: list[int] = [],
+    fdr_rate: float = 0.10,
+) -> dict[int, list[RankedRepnessStatement]]:
+    """
+    Ranks ALL statements per group by effect size and marks selections via Benjamini-Hochberg.
+
+    Args:
+        grouped_stats_df (pd.DataFrame): MultiIndex DataFrame of statement statistics, indexed by group and statement.
+        mod_out_statement_ids (list[int]): A list of statements to ignore.
+        fdr_rate (float): False discovery rate for BH procedure.
+
+    Returns:
+        A dict mapping group_id to a list of RankedRepnessStatement, sorted by effect_size descending.
+    """
+    mod_out_mask = grouped_stats_df.index.get_level_values("statement_id").isin(
+        mod_out_statement_ids
+    )
+    grouped_stats_df = grouped_stats_df[~mod_out_mask]  # type: ignore
+
+    result: dict[int, list[RankedRepnessStatement]] = {}
+
+    for gid, group_df in grouped_stats_df.groupby(level="group_id"):
+        group_df = group_df.reset_index()
+
+        # Per-direction p-values: probability test and representativeness test.
+        p_prob_a = z_to_pvalue(group_df["pat"].values)
+        p_rep_a = z_to_pvalue(group_df["rat"].values)
+        p_prob_d = z_to_pvalue(group_df["pdt"].values)
+        p_rep_d = z_to_pvalue(group_df["rdt"].values)
+
+        # Combine probability + representativeness p-values using Simes' method,
+        # which is valid under positive dependence (both tests use the same votes).
+        # For 2 tests: p_simes = min(2 * p_min, p_max).
+        p_simes_a = np.minimum(
+            2 * np.minimum(p_prob_a, p_rep_a), np.maximum(p_prob_a, p_rep_a)
+        )
+        p_simes_d = np.minimum(
+            2 * np.minimum(p_prob_d, p_rep_d), np.maximum(p_prob_d, p_rep_d)
+        )
+
+        # Pick the better direction (lower combined p-value).
+        agree_better = p_simes_a <= p_simes_d
+        p_combined = np.where(agree_better, p_simes_a, p_simes_d)
+        directions = np.where(agree_better, "agree", "disagree")
+
+        # Effect size: ra*pa for agree, rd*pd for disagree.
+        effect_agree = group_df["ra"].values * group_df["pa"].values
+        effect_disagree = group_df["rd"].values * group_df["pd"].values
+        effect_sizes = np.where(agree_better, effect_agree, effect_disagree)
+
+        # Apply BH with zero-vote filter.
+        has_votes = (group_df["na"].values > 0) | (group_df["nd"].values > 0)
+        selected_mask, adjusted = apply_bh_with_vote_filter(
+            p_combined, has_votes, fdr_rate
+        )
+
+        # Rank by effect size descending (1-based).
+        n = len(p_combined)
+        rank_order = np.argsort(-effect_sizes)
+        ranks = np.empty(n, dtype=int)
+        ranks[rank_order] = np.arange(1, n + 1)
+
+        # Build RankedRepnessStatement list, sorted by rank.
+        statements: list[RankedRepnessStatement] = []
+        for idx in rank_order:
+            row = group_df.iloc[idx]
+            statements.append(
+                RankedRepnessStatement(
+                    statement_id=int(row["statement_id"]),
+                    repful_for=directions[idx],
+                    na=int(row["na"]),
+                    nd=int(row["nd"]),
+                    ns=int(row["ns"]),
+                    pa=float(row["pa"]),
+                    pd=float(row["pd"]),
+                    pat=float(row["pat"]),
+                    pdt=float(row["pdt"]),
+                    ra=float(row["ra"]),
+                    rd=float(row["rd"]),
+                    rat=float(row["rat"]),
+                    rdt=float(row["rdt"]),
+                    effect_size=float(effect_sizes[idx]),
+                    p_value=float(p_combined[idx]),
+                    adjusted_p_value=float(adjusted[idx]),
+                    selected=bool(selected_mask[idx]),
+                    rank=int(ranks[idx]),
+                )
+            )
+
+        result[int(gid)] = statements
+
+    return result
 
 
 def populate_priority_calculations_into_statements_df(

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -607,18 +607,49 @@ def select_representative_statements(
     for gid, group_df in grouped_stats_df.groupby(level="group_id"):
         # Bring statement_id into regular column.
         group_df = group_df.reset_index()
-        actual_confidence = confidence
 
-        sig_filter = lambda row: is_statement_significant(row, actual_confidence)
+        sig_filter = lambda row: is_statement_significant(row, confidence)
         sufficient_statements_row_mask = group_df.apply(sig_filter, axis="columns")
         sufficient_statements = group_df[sufficient_statements_row_mask]
 
-        while len(sufficient_statements) == 0 and actual_confidence >= 0.65:
-            # lower confidence until finding statments
-            actual_confidence = actual_confidence - 0.05
-            sig_filter = lambda row: is_statement_significant(row, actual_confidence)
-            sufficient_statements_row_mask = group_df.apply(sig_filter, axis="columns")
-            sufficient_statements = group_df[sufficient_statements_row_mask]
+        statements_by_confidence = {}
+        statements_by_confidence[confidence] = sufficient_statements
+        actual_confidence = confidence
+        if confidence > 0.6:
+            # keep decreasing by 0.05 until reaching 0.60
+            for decreased_confidence in [
+                round(x, 2)
+                for x in [
+                    confidence - i * 0.05
+                    for i in range(int((confidence - 0.6) / 0.05) + 1)
+                ]
+            ]:
+                sig_filter = lambda row: is_statement_significant(
+                    row, decreased_confidence
+                )
+                sufficient_statements_row_mask = group_df.apply(
+                    sig_filter, axis="columns"
+                )
+                sufficient_statements_test = group_df[sufficient_statements_row_mask]
+                statements_by_confidence[decreased_confidence] = (
+                    sufficient_statements_test
+                )
+            # Step 1: Find all confidences that reach pick_max
+            candidates = [
+                c for c, s in statements_by_confidence.items() if len(s) == pick_max
+            ]
+
+            if candidates:
+                # If there are multiple, pick the highest confidence
+                best_confidence = max(candidates)
+            else:
+                # Otherwise, pick the highest confidence with the largest list below pick_max
+                max_len = max(len(s) for s in statements_by_confidence.values())
+                best_confidence = max(
+                    c for c, s in statements_by_confidence.items() if len(s) == max_len
+                )
+            sufficient_statements = statements_by_confidence[best_confidence]
+            actual_confidence = best_confidence
 
         # Finalize statements into output format.
         # TODO: Figure out how to finalize only at end in output. Change repness_metric?

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -324,9 +324,7 @@ def calculate_comment_statistics(
     )
 
 
-def format_comment_stats(
-    statement: pd.Series, confidence: float
-) -> PolisRepnessStatement:
+def format_comment_stats(statement: pd.Series) -> PolisRepnessStatement:
     """
     Format internal statistics into concise agree/disagree format.
     Uses either consensus style or group-repness style depending on available fields.

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Literal
 from types import SimpleNamespace
 from scipy.stats import norm
 from reddwarf.utils.matrix import VoteMatrix
@@ -82,6 +82,15 @@ def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
     )
 
     return is_agreement_significant or is_disagreement_significant
+
+
+def get_statement_significant_for(
+    pat: float, rat: float, pdt: float, rdt: float
+) -> Literal["agree", "disagree"]:
+    "Get if statement is significant for agree or disagree"
+    is_repful_for_agree = pat + rat >= pdt + rdt
+    is_repful = "agree" if is_repful_for_agree else "disagree"
+    return is_repful
 
 
 def beats_best_by_repness_test(
@@ -314,7 +323,9 @@ def calculate_comment_statistics(
     )
 
 
-def format_comment_stats(statement: pd.Series) -> PolisRepnessStatement:
+def format_comment_stats(
+    statement: pd.Series, confidence: float
+) -> PolisRepnessStatement:
     """
     Format internal statistics into concise agree/disagree format.
     Uses either consensus style or group-repness style depending on available fields.
@@ -346,15 +357,19 @@ def format_comment_stats(statement: pd.Series) -> PolisRepnessStatement:
 
     # Select score source
     if format_style == "group-repness":
-        score_agree = float(statement["rat"])
-        score_disagree = float(statement["rdt"])
+        repful_for = get_statement_significant_for(
+            pat=statement["pat"],
+            rat=statement["rat"],
+            pdt=statement["pdt"],
+            rdt=statement["rdt"],
+        )
     else:
         score_agree = float(statement["pat"])
         score_disagree = float(statement["pdt"])
+        use_agree = score_agree >= score_disagree
+        repful_for = "agree" if use_agree else "disagree"
 
-    use_agree = score_agree > score_disagree
-    fields = agree_fields if use_agree else disagree_fields
-    direction = "agree" if use_agree else "disagree"
+    fields = agree_fields if repful_for == "agree" else disagree_fields
 
     result = {
         "tid": int(statement["statement_id"]),
@@ -367,9 +382,9 @@ def format_comment_stats(statement: pd.Series) -> PolisRepnessStatement:
     if format_style == "group-repness":
         result["repness"] = float(statement[fields["repness"]])
         result["repness-test"] = float(statement[fields["repness-test"]])
-        result["repful-for"] = direction
+        result["repful-for"] = repful_for
     else:
-        result["cons-for"] = direction
+        result["cons-for"] = repful_for
 
     return result
 
@@ -450,7 +465,7 @@ def calculate_comment_statistics_dataframes(
         {
             "group-aware-consensus": C_v_c[votes.A, :],
             "group-aware-consensus-agree": C_v_c[votes.A, :],
-            "group-aware-consensus-disagree": C_v_c[votes.D, :]
+            "group-aware-consensus-disagree": C_v_c[votes.D, :],
         },
         index=vote_matrix.columns,
     )

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -612,44 +612,49 @@ def select_representative_statements(
         sufficient_statements_row_mask = group_df.apply(sig_filter, axis="columns")
         sufficient_statements = group_df[sufficient_statements_row_mask]
 
-        # Track the best, even if doesn't meet sufficient minimum, to have at least one.
-        best_overall = None
+        actual_confidence = confidence
+        while len(sufficient_statements) == 0 and actual_confidence - 0.10 >= 0:
+            # lower confidence until finding statments
+            actual_confidence = actual_confidence - 0.10
+            sig_filter_updated = lambda row: is_statement_significant(
+                row, actual_confidence
+            )
+            sufficient_statements_row_mask = group_df.apply(
+                sig_filter_updated, axis="columns"
+            )
+            sufficient_statements = group_df[sufficient_statements_row_mask]
+        # Finalize statements into output format.
+        # TODO: Figure out how to finalize only at end in output. Change repness_metric?
+        sufficient_statements = (
+            pd.DataFrame(
+                [
+                    format_comment_stats(row, confidence)
+                    for _, row in sufficient_statements.iterrows()
+                ]
+            )
+            # Create a column to sort repnress, then remove.
+            .assign(repness_metric=repness_metric)
+            .sort_values(by="repness_metric", ascending=False)
+            .drop(columns="repness_metric")
+        )
+
         if len(sufficient_statements) == 0:
+            best_overall = None
             for _, row in group_df.iterrows():
                 if beats_best_by_repness_test(row, best_overall):
                     best_overall = row
+            selected = [best_overall]
         else:
-            # Finalize statements into output format.
-            # TODO: Figure out how to finalize only at end in output. Change repness_metric?
-            sufficient_statements = (
-                pd.DataFrame(
-                    [
-                        format_comment_stats(row, confidence)
-                        for _, row in sufficient_statements.iterrows()
-                    ]
-                )
-                # Create a column to sort repnress, then remove.
-                .assign(repness_metric=repness_metric)
-                .sort_values(by="repness_metric", ascending=False)
-                .drop(columns="repness_metric")
+            selected = [row.to_dict() for _, row in sufficient_statements.iterrows()]
+            # Sort to put the most representatives first
+            selected = sorted(
+                selected, key=lambda row: row["repness-test"], reverse=True
             )
+            # Only then, pick up to pick_max statements
+            selected = selected[:pick_max]
+            # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
+            selected = sorted(selected, key=lambda row: row["repful-for"])
 
-        if best_overall is not None:
-            best_overall = format_comment_stats(best_overall, confidence)
-            best_head = [best_overall]
-        else:
-            best_head = []
-
-        selected = best_head
-        selected = selected + [
-            row.to_dict() for _, row in sufficient_statements.iterrows()
-        ]
-        # Sort to put the most representatives first
-        selected = sorted(selected, key=lambda row: row["repness-test"], reverse=True)
-        # Only then, pick up to pick_max statements
-        selected = selected[:pick_max]
-        # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
-        selected = sorted(selected, key=lambda row: row["repful-for"])
         repness[gid] = selected
 
     return repness  # type:ignore

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -71,33 +71,55 @@ def is_significant(z_val: float, confidence: float = 0.90) -> bool:
     return z_val > critical_value  # rat/rdt can be negative
 
 
-def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
+def is_statement_agree_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
-    pat, rat, pdt, rdt, tid = [
-        row[col] for col in ["pat", "rat", "pdt", "rdt", "statement_id"]
-    ]
+    pat, rat = [row[col] for col in ["pat", "rat"]]
     is_agreement_significant = is_significant(pat, confidence) and is_significant(
         rat, confidence
     )
+    return is_agreement_significant
+
+
+def is_statement_disagree_significant(row: pd.Series, confidence=0.90) -> bool:
+    "Decide whether we should count a statement in a group as being representative."
+    pdt, rdt = [row[col] for col in ["pdt", "rdt"]]
     is_disagreement_significant = is_significant(pdt, confidence) and is_significant(
         rdt, confidence
     )
-    if tid == 2460:
-        print(
-            f"pat={pat}, rat={rat}, pdt={pdt}, rdt={rdt}, confidence={confidence}, calc_confidence={norm.ppf(confidence)}, is_agreement_significant={is_agreement_significant}, is_disagreement_significant={is_disagreement_significant}"
-        )
+    return is_disagreement_significant
+
+
+def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
+    "Decide whether we should count a statement in a group as being representative."
+    is_agreement_significant = is_statement_agree_significant(row, confidence)
+    is_disagreement_significant = is_statement_disagree_significant(row, confidence)
 
     return is_agreement_significant or is_disagreement_significant
 
 
-def get_statement_significant_for(
-    pat: float, pdt: float
+def get_statement_repful_for(
+    row: pd.Series, confidence=0.90
 ) -> Literal["agree", "disagree"]:
-    "Get if statement is significant for agree or disagree"
-    is_repful_for_agree = pat > pdt
-    # # rat/rdt can be negative, probably not the case for pat/pdt
-    is_repful = "agree" if is_repful_for_agree else "disagree"
-    return "agree"  # testing
+    "Get if statement is significant for agree or disagree."
+    has_repness = "rat" in row and "rdt" in row
+    format_style = "group-repness" if has_repness else "consensus"
+
+    if format_style == "consensus":
+        pat, pdt = [row[col] for col in ["rat", "rdt"]]
+        is_repful_for_agree = pat > pdt
+        repful_for = "agree" if is_repful_for_agree else "disagree"
+        return repful_for
+
+    # now rat and rdt exist
+    if is_statement_agree_significant(row, confidence):
+        return "agree"
+    if is_statement_disagree_significant(row, confidence):
+        return "disagree"
+    # This should not happen if it is called when the statement has already been identified as significant...
+    rat, rdt = [row[col] for col in ["rat", "rdt"]]
+    is_repful_for_agree = rat > rdt
+    repful_for = "agree" if is_repful_for_agree else "disagree"
+    return repful_for
 
 
 def beats_best_by_repness_test(
@@ -330,7 +352,10 @@ def calculate_comment_statistics(
     )
 
 
-def format_comment_stats(statement: pd.Series) -> PolisRepnessStatement:
+def format_comment_stats(
+    statement: pd.Series,
+    confidence: float = 0.90,
+) -> PolisRepnessStatement:
     """
     Format internal statistics into concise agree/disagree format.
     Uses either consensus style or group-repness style depending on available fields.
@@ -361,9 +386,7 @@ def format_comment_stats(statement: pd.Series) -> PolisRepnessStatement:
     }
 
     # Select score source
-    repful_for = get_statement_significant_for(
-        pat=statement["pat"], pdt=statement["pdt"]
-    )
+    repful_for = get_statement_repful_for(statement, confidence)
 
     fields = agree_fields if repful_for == "agree" else disagree_fields
 
@@ -582,12 +605,6 @@ def select_representative_statements(
         # Bring statement_id into regular column.
         group_df = group_df.reset_index()
 
-        best_agree = None
-        # Track the best-agree, to bring to top if exists.
-        for _, row in group_df.iterrows():
-            if beats_best_of_agrees(row, best_agree, confidence):
-                best_agree = row
-
         sig_filter = lambda row: is_statement_significant(row, confidence)
         sufficient_statements_row_mask = group_df.apply(sig_filter, axis="columns")
         sufficient_statements = group_df[sufficient_statements_row_mask]
@@ -604,7 +621,7 @@ def select_representative_statements(
             sufficient_statements = (
                 pd.DataFrame(
                     [
-                        format_comment_stats(row)
+                        format_comment_stats(row, confidence)
                         for _, row in sufficient_statements.iterrows()
                     ]
                 )
@@ -614,12 +631,8 @@ def select_representative_statements(
                 .drop(columns="repness_metric")
             )
 
-        if best_agree is not None:
-            best_agree = format_comment_stats(best_agree)
-            best_agree.update({"n-agree": best_agree["n-success"], "best-agree": True})
-            best_head = [best_agree]
-        elif best_overall is not None:
-            best_overall = format_comment_stats(best_overall)
+        if best_overall is not None:
+            best_overall = format_comment_stats(best_overall, confidence)
             best_head = [best_overall]
         else:
             best_head = []

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -74,7 +74,10 @@ def is_significant(z_val: float, confidence: float = 0.90) -> bool:
 
 def is_statement_agree_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
-    pat, rat = [row[col] for col in ["pat", "rat"]]
+    pat, rat, na, nd = [row[col] for col in ["pat", "rat", "na", "nd"]]
+    # Explicitly don't allow something that hasn't been voted on at all
+    if na == 0 and nd == 0:
+        return False
     is_agreement_significant = is_significant(pat, confidence) and is_significant(
         rat, confidence
     )
@@ -83,7 +86,10 @@ def is_statement_agree_significant(row: pd.Series, confidence=0.90) -> bool:
 
 def is_statement_disagree_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
-    pdt, rdt = [row[col] for col in ["pdt", "rdt"]]
+    pdt, rdt, na, nd = [row[col] for col in ["pdt", "rdt", "na", "nd"]]
+    # Explicitly don't allow something that hasn't been voted on at all
+    if na == 0 and nd == 0:
+        return False
     is_disagreement_significant = is_significant(pdt, confidence) and is_significant(
         rdt, confidence
     )
@@ -656,11 +662,8 @@ def select_representative_statements(
                 # If there are multiple, pick the highest confidence
                 best_confidence = max(candidates)
             else:
-                # Otherwise, pick the highest confidence with the largest list below pick_max - 2
-                max_len = max(len(s) for s in statements_by_confidence.values())
-                best_confidence = max(
-                    c for c, s in statements_by_confidence.items() if len(s) == max_len
-                )
+                # Otherwise, pick the highest confidence
+                best_confidence = max(statements_by_confidence.items())
             sufficient_statements = statements_by_confidence[best_confidence]
             actual_confidence = best_confidence
 

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -607,28 +607,15 @@ def select_representative_statements(
     for gid, group_df in grouped_stats_df.groupby(level="group_id"):
         # Bring statement_id into regular column.
         group_df = group_df.reset_index()
+        actual_confidence = confidence
 
-        sig_filter = lambda row: is_statement_significant(row, confidence)
+        sig_filter = lambda row: is_statement_significant(row, actual_confidence)
         sufficient_statements_row_mask = group_df.apply(sig_filter, axis="columns")
         sufficient_statements = group_df[sufficient_statements_row_mask]
-
-        actual_confidence = confidence
-        while len(sufficient_statements) == 0 and actual_confidence - 0.10 >= 0:
-            # lower confidence until finding statments
-            actual_confidence = actual_confidence - 0.10
-            sig_filter_updated = lambda row: is_statement_significant(
-                row, actual_confidence
-            )
-            sufficient_statements_row_mask = group_df.apply(
-                sig_filter_updated, axis="columns"
-            )
-            sufficient_statements = group_df[sufficient_statements_row_mask]
-        # Finalize statements into output format.
-        # TODO: Figure out how to finalize only at end in output. Change repness_metric?
         sufficient_statements = (
             pd.DataFrame(
                 [
-                    format_comment_stats(row, confidence)
+                    format_comment_stats(row, actual_confidence)
                     for _, row in sufficient_statements.iterrows()
                 ]
             )
@@ -638,22 +625,50 @@ def select_representative_statements(
             .drop(columns="repness_metric")
         )
 
+        selected = [row.to_dict() for _, row in sufficient_statements.iterrows()]
+        while len(sufficient_statements) < pick_max and actual_confidence - 0.05 >= 0.6:
+            # lower confidence until finding statments
+            actual_confidence = actual_confidence - 0.05
+            sig_filter_updated = lambda row: is_statement_significant(
+                row, actual_confidence
+            )
+            sufficient_statements_row_mask = group_df.apply(
+                sig_filter_updated, axis="columns"
+            )
+            sufficient_statements_to_add = group_df[sufficient_statements_row_mask]
+            sufficient_statements_to_add = (
+                pd.DataFrame(
+                    [
+                        format_comment_stats(row, actual_confidence)
+                        for _, row in sufficient_statements_to_add.iterrows()
+                    ]
+                )
+                # Create a column to sort repnress, then remove.
+                .assign(repness_metric=repness_metric)
+                .sort_values(by="repness_metric", ascending=False)
+                .drop(columns="repness_metric")
+            )
+            selected = selected + [
+                row.to_dict() for _, row in sufficient_statements_to_add.iterrows()
+            ]
+
+        # Finalize statements into output format.
+        # TODO: Figure out how to finalize only at end in output. Change repness_metric?
+
+        # most likely won't happen
         if len(sufficient_statements) == 0:
             best_overall = None
             for _, row in group_df.iterrows():
                 if beats_best_by_repness_test(row, best_overall):
                     best_overall = row
             selected = [best_overall]
-        else:
-            selected = [row.to_dict() for _, row in sufficient_statements.iterrows()]
-            # Sort to put the most representatives first
-            selected = sorted(
-                selected, key=lambda row: row["repness-test"], reverse=True
-            )
-            # Only then, pick up to pick_max statements
-            selected = selected[:pick_max]
-            # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
-            selected = sorted(selected, key=lambda row: row["repful-for"])
+
+        # Sort to put the most representatives first
+        selected = sorted(selected, key=lambda row: row["repness-test"], reverse=True)
+        # Only then, pick up to pick_max statements
+        selected = selected[:pick_max]
+        # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
+        selected = sorted(selected, key=lambda row: row["repful-for"])
 
         repness[gid] = selected
 

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -645,7 +645,7 @@ def select_representative_statements(
             row.to_dict() for _, row in sufficient_statements.iterrows()
         ]
         # Sort to put the most representatives first
-        selected = sorted(selected, key=lambda row: row["repness_test"], reverse=True)
+        selected = sorted(selected, key=lambda row: row["repness-test"], reverse=True)
         # Only then, pick up to pick_max statements
         selected = selected[:pick_max]
         # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -100,6 +100,11 @@ def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
     return is_agreement_significant or is_disagreement_significant
 
 
+# DIVERGENCE FROM POLIS: Polis determines repful_for using the higher of
+# ra (agree representativeness ratio) vs rd (disagree representativeness ratio).
+# We instead use significance tests (rat/rdt z-scores) with a confidence
+# threshold, falling back to the raw z-score comparison only when neither
+# direction passes the significance test.
 def get_statement_repful_for(
     row: pd.Series, confidence=0.90
 ) -> Literal["agree", "disagree"]:
@@ -338,14 +343,29 @@ def calculate_comment_statistics(
         )  # rdt
 
     # Calculate group-aware consensus
-    # Geometric mean: normalize for group count so that similar levels of
-    # cross-group consensus produce similar scores regardless of whether
-    # the conversation has 2 or 6 opinion groups. This helps when applying
-    # a selection algorithm with a fixed threshold (e.g. 0.5).
-    # Reference: https://github.com/compdemocracy/polis/blob/edge/math/src/polismath/math/conversation.clj#L615-L636
+    # Reference (original Polis): https://github.com/compdemocracy/polis/blob/edge/math/src/polismath/math/conversation.clj#L615-L636
+    #
+    # DIVERGENCE #1 FROM POLIS (geometric mean):
+    # Polis uses a raw product of per-group probabilities. This shrinks
+    # exponentially with more groups, making consensus scores unreachable
+    # for conversations with 4-6 opinion groups. We use a geometric mean
+    # (prod^(1/n_groups)) so that similar levels of cross-group consensus
+    # produce similar scores regardless of group count.
+    #
+    # DIVERGENCE #2 FROM POLIS (effective agreement):
+    # Polis uses raw p_agree per group, ignoring p_disagree entirely. This
+    # means a group that is genuinely divided (similar levels of agree and
+    # disagree) contributes the same score as an undivided group with the
+    # same agree level — allowing divided groups to be masked by other
+    # groups' strong agreement. We fix this by using "effective agreement":
+    # p_agree * (1 - p_disagree), which discounts each group's agreement
+    # by its disagreement so a divided group naturally drags down the
+    # consensus score.
     n_groups = P_v_g_c.shape[1]
-    C_v_c[votes.A, :] = P_v_g_c[votes.A, :, :].prod(axis=0) ** (1.0 / n_groups)
-    C_v_c[votes.D, :] = P_v_g_c[votes.D, :, :].prod(axis=0) ** (1.0 / n_groups)
+    effective_agree = P_v_g_c[votes.A, :, :] * (1 - P_v_g_c[votes.D, :, :])
+    effective_disagree = P_v_g_c[votes.D, :, :] * (1 - P_v_g_c[votes.A, :, :])
+    C_v_c[votes.A, :] = effective_agree.prod(axis=0) ** (1.0 / n_groups)
+    C_v_c[votes.D, :] = effective_disagree.prod(axis=0) ** (1.0 / n_groups)
 
     return (
         N_g_c,  # ns
@@ -581,6 +601,13 @@ def priority_metric(
 # Figuring out select-rep-comments flow
 # See: https://github.com/compdemocracy/polis/blob/7bf9eccc287586e51d96fdf519ae6da98e0f4a70/math/src/polismath/math/repness.clj#L209C7-L209C26
 # TODO: omg please clean this up.
+#
+# DIVERGENCE FROM POLIS: Polis uses a fixed confidence level and may return
+# fewer than pick_max statements when not enough pass the significance test.
+# We progressively lower the confidence from the initial value down to 0.60
+# (in 0.05 steps) to fill up to pick_max representative statements. If no
+# statements pass even the lowest confidence, we fall back to the single
+# best statement by repness z-score.
 def select_representative_statements(
     grouped_stats_df: pd.DataFrame,
     mod_out_statement_ids: list[int] = [],
@@ -589,8 +616,6 @@ def select_representative_statements(
 ) -> PolisRepness:
     """
     Selects statistically representative statements from each group cluster.
-
-    This is expected to match the Polis outputs when all defaults are set.
 
     Args:
         grouped_stats_df (pd.DataFrame): MultiIndex Dataframe of statement statistics, indexed by group and statement.

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -73,24 +73,30 @@ def is_significant(z_val: float, confidence: float = 0.90) -> bool:
 
 def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
     "Decide whether we should count a statement in a group as being representative."
-    pat, rat, pdt, rdt = [row[col] for col in ["pat", "rat", "pdt", "rdt"]]
+    pat, rat, pdt, rdt, tid = [
+        row[col] for col in ["pat", "rat", "pdt", "rdt", "statement_id"]
+    ]
     is_agreement_significant = is_significant(pat, confidence) and is_significant(
         rat, confidence
     )
     is_disagreement_significant = is_significant(pdt, confidence) and is_significant(
         rdt, confidence
     )
+    if tid == 2460:
+        print(
+            f"pat={pat}, rat={rat}, pdt={pdt}, rdt={rdt}, confidence={confidence}, calc_confidence={norm.ppf(confidence)}, is_agreement_significant={is_agreement_significant}, is_disagreement_significant={is_disagreement_significant}"
+        )
 
     return is_agreement_significant or is_disagreement_significant
 
 
 def get_statement_significant_for(
-    pat: float, rat: float, pdt: float, rdt: float
+    pat: float, pdt: float
 ) -> Literal["agree", "disagree"]:
     "Get if statement is significant for agree or disagree"
-    # is_repful_for_agree = pat > pdt
+    is_repful_for_agree = pat > pdt
     # # rat/rdt can be negative, probably not the case for pat/pdt
-    # is_repful = "agree" if is_repful_for_agree else "disagree"
+    is_repful = "agree" if is_repful_for_agree else "disagree"
     return "agree"  # testing
 
 
@@ -355,18 +361,9 @@ def format_comment_stats(statement: pd.Series) -> PolisRepnessStatement:
     }
 
     # Select score source
-    if format_style == "group-repness":
-        repful_for = get_statement_significant_for(
-            pat=statement["pat"],
-            rat=statement["rat"],
-            pdt=statement["pdt"],
-            rdt=statement["rdt"],
-        )
-    else:
-        score_agree = float(statement["pat"])
-        score_disagree = float(statement["pdt"])
-        use_agree = score_agree > score_disagree
-        repful_for = "agree" if use_agree else "disagree"
+    repful_for = get_statement_significant_for(
+        pat=statement["pat"], pdt=statement["pdt"]
+    )
 
     fields = agree_fields if repful_for == "agree" else disagree_fields
 

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -663,9 +663,6 @@ def select_representative_statements(
                     best_overall = row
             selected = [best_overall]
 
-        # Sort to put the most representatives first
-        selected = sorted(selected, key=lambda row: row["repness-test"], reverse=True)
-        # Only then, pick up to pick_max statements
         selected = selected[:pick_max]
         # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
         selected = sorted(selected, key=lambda row: row["repful-for"])

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -68,7 +68,7 @@ def two_prop_test(
 def is_significant(z_val: float, confidence: float = 0.90) -> bool:
     """Test whether z-statistic is significant at 90% confidence (one-tailed, right-side)."""
     critical_value = norm.ppf(confidence)  # 90% confidence level, one-tailed
-    return abs(z_val) > critical_value  # rat/rdt can be negative
+    return z_val > critical_value  # rat/rdt can be negative
 
 
 def is_statement_significant(row: pd.Series, confidence=0.90) -> bool:
@@ -88,9 +88,8 @@ def get_statement_significant_for(
     pat: float, rat: float, pdt: float, rdt: float
 ) -> Literal["agree", "disagree"]:
     "Get if statement is significant for agree or disagree"
-    is_repful_for_agree = abs(pat) >= abs(
-        pdt
-    )  # rat/rdt can be negative, probably not the case for pat/pdt
+    is_repful_for_agree = pat > pdt
+    # rat/rdt can be negative, probably not the case for pat/pdt
     is_repful = "agree" if is_repful_for_agree else "disagree"
     return is_repful
 
@@ -368,7 +367,7 @@ def format_comment_stats(
     else:
         score_agree = float(statement["pat"])
         score_disagree = float(statement["pdt"])
-        use_agree = score_agree >= score_disagree
+        use_agree = score_agree > score_disagree
         repful_for = "agree" if use_agree else "disagree"
 
     fields = agree_fields if repful_for == "agree" else disagree_fields

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -642,12 +642,11 @@ def select_representative_statements(
 
         selected = best_head
         selected = selected + [
-            row.to_dict()
-            for _, row in sufficient_statements.iterrows()
-            if best_head
-            # Skip any statements already in best_head
-            and best_head[0]["tid"] != row["tid"]
+            row.to_dict() for _, row in sufficient_statements.iterrows()
         ]
+        # Sort to put the most representatives first
+        selected = sorted(selected, key=lambda row: row["repness_test"], reverse=True)
+        # Only then, pick up to pick_max statements
         selected = selected[:pick_max]
         # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
         selected = sorted(selected, key=lambda row: row["repful-for"])

--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -68,7 +68,7 @@ def two_prop_test(
 def is_significant(z_val: float, confidence: float = 0.90) -> bool:
     """Test whether z-statistic is significant at 90% confidence (one-tailed, right-side)."""
     critical_value = norm.ppf(confidence)  # 90% confidence level, one-tailed
-    return z_val > critical_value  # rat/rdt can be negative
+    return z_val > critical_value
 
 
 def is_statement_agree_significant(row: pd.Series, confidence=0.90) -> bool:
@@ -615,13 +615,13 @@ def select_representative_statements(
         statements_by_confidence = {}
         statements_by_confidence[confidence] = sufficient_statements
         actual_confidence = confidence
-        if confidence > 0.6:
-            # keep decreasing by 0.05 until reaching 0.60
+        if confidence > 0.7:
+            # keep decreasing by 0.05 until reaching 0.70
             for decreased_confidence in [
                 round(x, 2)
                 for x in [
                     confidence - i * 0.05
-                    for i in range(int((confidence - 0.6) / 0.05) + 1)
+                    for i in range(int((confidence - 0.7) / 0.05) + 1)
                 ]
             ]:
                 sig_filter = lambda row: is_statement_significant(
@@ -634,16 +634,16 @@ def select_representative_statements(
                 statements_by_confidence[decreased_confidence] = (
                     sufficient_statements_test
                 )
-            # Step 1: Find all confidences that reach pick_max
+            # Step 1: Find all confidences that reach pick_max - 2
             candidates = [
-                c for c, s in statements_by_confidence.items() if len(s) == pick_max
+                c for c, s in statements_by_confidence.items() if len(s) >= pick_max - 2
             ]
 
             if candidates:
                 # If there are multiple, pick the highest confidence
                 best_confidence = max(candidates)
             else:
-                # Otherwise, pick the highest confidence with the largest list below pick_max
+                # Otherwise, pick the highest confidence with the largest list below pick_max - 2
                 max_len = max(len(s) for s in statements_by_confidence.values())
                 best_confidence = max(
                     c for c, s in statements_by_confidence.items() if len(s) == max_len
@@ -678,6 +678,11 @@ def select_representative_statements(
             selected = selected[:pick_max]
             # Does the work of agrees-before-disagrees sort in polismath, since "a" before "d".
             selected = sorted(selected, key=lambda row: row["repful-for"])
+
+        # TODO: improve best agree alg
+        if len(selected) > 0 and selected[0] is not None:
+            if selected[0]["repful-for"] == "agree":
+                selected[0]["best-agree"] = True
 
         repness[gid] = selected
 

--- a/scripts/print_agora_snapshot.py
+++ b/scripts/print_agora_snapshot.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Print Agora pipeline snapshot for cram testing.
+
+Runs the Agora pipeline on fixture data and prints human-readable output
+showing representative opinions, group-aware consensus, and divisive
+statements with cross-group comparisons.
+"""
+import sys
+
+from reddwarf.data_loader import Loader
+from reddwarf.implementations.agora import run_pipeline
+from reddwarf.utils.consensus import select_consensus_statements
+from reddwarf.utils.statements import process_statements
+from reddwarf.utils.stats import select_representative_statements
+
+
+def truncate(text, max_len=30):
+    if len(text) <= max_len:
+        return f'"{text}"'
+    return f'"{text[:max_len]}..."'
+
+
+def format_votes(na, nd, ns):
+    return f"{na:>2}/{nd:>2}/{ns:>2}"
+
+
+def main():
+    fixture_dir = sys.argv[1] if len(sys.argv) > 1 else "tests/fixtures/below-100-ptpts"
+
+    loader = Loader(filepaths=[
+        f"{fixture_dir}/votes.json",
+        f"{fixture_dir}/comments.json",
+        f"{fixture_dir}/conversation.json",
+    ])
+
+    _, _, mod_out_statement_ids, meta_statement_ids = process_statements(
+        statement_data=loader.comments_data
+    )
+
+    stmt_text = {}
+    for c in loader.comments_data:
+        sid = c.get("tid", c.get("statement_id"))
+        stmt_text[sid] = c.get("txt", "")
+
+    result = run_pipeline(
+        votes=loader.votes_data,
+        mod_out_statement_ids=mod_out_statement_ids,
+        meta_statement_ids=meta_statement_ids,
+        random_state=42,
+    )
+
+    group_ids = sorted(result.ranked_repness.keys())
+    n_groups = len(group_ids)
+    n_clustered = len(result.participants_df[result.participants_df["to_cluster"]])
+    n_statements = len(result.statements_df)
+    n_mod_out = len(mod_out_statement_ids)
+    stats = result.group_comment_stats
+    gac = result.group_aware_consensus
+
+    # Header
+    print("=== AGORA PIPELINE SNAPSHOT ===")
+    print(f"Fixture: {fixture_dir}")
+    print(f"Participants: {n_clustered} clustered, {n_groups} groups")
+    print(f"Statements: {n_statements - n_mod_out} active ({n_mod_out} moderated out)")
+
+    # Representative opinions
+    print()
+    print("=== REPRESENTATIVE OPINIONS ===")
+    for gid in group_ids:
+        print()
+        print(f"--- Group {gid} ---")
+        print(f" #  Sel  Dir    Stmt  Effect  Text")
+        print(f"{'':>33}{' |'.join(f'  G{g} pa/pd (na/nd/ns)' for g in group_ids)}")
+        for s in result.ranked_repness[gid]:
+            sel = "[*]" if s.selected else "[ ]"
+            direction = "agree" if s.repful_for == "agree" else "dis  "
+            text = truncate(stmt_text.get(s.statement_id, "?"), 30)
+            print(f"{s.rank:>2}  {sel}  {direction}  s{s.statement_id:<3}  {s.effect_size:.4f}  {text}")
+            # Cross-group comparison line
+            parts = []
+            for g in group_ids:
+                row = stats.loc[(g, s.statement_id)]
+                pa, pd_val = row["pa"], row["pd"]
+                na, nd, ns = int(row["na"]), int(row["nd"]), int(row["ns"])
+                parts.append(f"  {pa:.2f}/{pd_val:.2f} ({format_votes(na, nd, ns)})")
+            print(f"{'':>33}{' |'.join(parts)}")
+
+    # Filter mod_out from GAC for display consistency with other sections
+    active_gac_agree = [(sid, score) for sid, score in gac["agree"].items() if sid not in mod_out_statement_ids]
+    active_gac_disagree = [(sid, score) for sid, score in gac["disagree"].items() if sid not in mod_out_statement_ids]
+
+    # Group-aware consensus (agree)
+    print()
+    print("=== GROUP-AWARE CONSENSUS (AGREE) ===")
+    sorted_agree = sorted(active_gac_agree, key=lambda x: x[1], reverse=True)
+    print(f" #  Stmt  GAC     Text")
+    print(f"{'':>24}{' |'.join(f'  G{g} pa (na/nd/ns)' for g in group_ids)}")
+    for rank, (sid, score) in enumerate(sorted_agree, 1):
+        text = truncate(stmt_text.get(sid, "?"), 30)
+        print(f"{rank:>2}  s{sid:<3}  {score:.4f}  {text}")
+        parts = []
+        for g in group_ids:
+            row = stats.loc[(g, sid)]
+            pa = row["pa"]
+            na, nd, ns = int(row["na"]), int(row["nd"]), int(row["ns"])
+            parts.append(f"  {pa:.2f} ({format_votes(na, nd, ns)})")
+        print(f"{'':>24}{' |'.join(parts)}")
+
+    # Group-aware consensus (disagree)
+    print()
+    print("=== GROUP-AWARE CONSENSUS (DISAGREE) ===")
+    sorted_disagree = sorted(active_gac_disagree, key=lambda x: x[1], reverse=True)
+    print(f" #  Stmt  GAC     Text")
+    print(f"{'':>24}{' |'.join(f'  G{g} pd (na/nd/ns)' for g in group_ids)}")
+    for rank, (sid, score) in enumerate(sorted_disagree, 1):
+        text = truncate(stmt_text.get(sid, "?"), 30)
+        print(f"{rank:>2}  s{sid:<3}  {score:.4f}  {text}")
+        parts = []
+        for g in group_ids:
+            row = stats.loc[(g, sid)]
+            pd_val = row["pd"]
+            na, nd, ns = int(row["na"]), int(row["nd"]), int(row["ns"])
+            parts.append(f"  {pd_val:.2f} ({format_votes(na, nd, ns)})")
+        print(f"{'':>24}{' |'.join(parts)}")
+
+    # Consensus statements (agree)
+    print()
+    print("=== CONSENSUS STATEMENTS (AGREE) ===")
+    print(f" #  Sel  Stmt  Effect  pa    na/nd/ns  p_adj    Text")
+    for s in result.ranked_consensus.agree:
+        sel = "[*]" if s.selected else "[ ]"
+        text = truncate(stmt_text.get(s.statement_id, "?"), 30)
+        print(f"{s.rank:>2}  {sel}  s{s.statement_id:<3}  {s.effect_size:.4f}  {s.pa:.2f}  {format_votes(s.na, s.nd, s.ns)}  {s.adjusted_p_value:.4f}  {text}")
+
+    # Consensus statements (disagree)
+    print()
+    print("=== CONSENSUS STATEMENTS (DISAGREE) ===")
+    print(f" #  Sel  Stmt  Effect  pd    na/nd/ns  p_adj    Text")
+    for s in result.ranked_consensus.disagree:
+        sel = "[*]" if s.selected else "[ ]"
+        text = truncate(stmt_text.get(s.statement_id, "?"), 30)
+        print(f"{s.rank:>2}  {sel}  s{s.statement_id:<3}  {s.effect_size:.4f}  {s.pd:.2f}  {format_votes(s.na, s.nd, s.ns)}  {s.adjusted_p_value:.4f}  {text}")
+
+    # Divisive statements
+    print()
+    print("=== DIVISIVE STATEMENTS ===")
+    # Compute divergence: max absolute difference in pa across any pair of groups
+    statement_ids = [sid for sid in result.statements_df.index if sid not in mod_out_statement_ids]
+    divergences = []
+    for sid in statement_ids:
+        pa_values = [stats.loc[(g, sid), "pa"] for g in group_ids]
+        max_diff = max(pa_values) - min(pa_values)
+        divergences.append((sid, max_diff))
+    divergences.sort(key=lambda x: x[1], reverse=True)
+
+    print(f" #  Stmt  Div     Text")
+    print(f"{'':>24}{' |'.join(f'  G{g} pa/pd (na/nd/ns)' for g in group_ids)}")
+    for rank, (sid, div) in enumerate(divergences, 1):
+        text = truncate(stmt_text.get(sid, "?"), 30)
+        print(f"{rank:>2}  s{sid:<3}  {div:.4f}  {text}")
+        parts = []
+        for g in group_ids:
+            row = stats.loc[(g, sid)]
+            pa, pd_val = row["pa"], row["pd"]
+            na, nd, ns = int(row["na"]), int(row["nd"]), int(row["ns"])
+            parts.append(f"  {pa:.2f}/{pd_val:.2f} ({format_votes(na, nd, ns)})")
+        print(f"{'':>24}{' |'.join(parts)}")
+
+    # Selection comparison: Polis vs Agora
+    polis_repness = select_representative_statements(
+        grouped_stats_df=result.group_comment_stats,
+        mod_out_statement_ids=mod_out_statement_ids,
+    )
+    polis_consensus = select_consensus_statements(
+        vote_matrix=result.raw_vote_matrix,
+        mod_out_statement_ids=mod_out_statement_ids,
+    )
+
+    print()
+    print("=== SELECTION COMPARISON ===")
+
+    def fmt_stmt(sid, direction):
+        d = "a" if direction == "agree" else "d"
+        return f"s{sid}({d})"
+
+    print()
+    print("--- Repness ---")
+    for gid in group_ids:
+        polis_stmts = [fmt_stmt(s["tid"], s["repful-for"]) for s in polis_repness.get(gid, [])]
+        agora_stmts = [fmt_stmt(s.statement_id, s.repful_for) for s in result.ranked_repness[gid] if s.selected]
+        polis_str = " ".join(polis_stmts) if polis_stmts else "(none)"
+        agora_str = " ".join(agora_stmts) if agora_stmts else "(none)"
+        print(f"Group {gid}:")
+        print(f"  Polis (pick_max=5): {polis_str}")
+        print(f"  Agora (BH fdr=0.10): {agora_str}")
+
+    print()
+    print("--- Consensus (agree) ---")
+    polis_agree = [f"s{s['tid']}" for s in polis_consensus["agree"]]
+    agora_agree = [f"s{s.statement_id}" for s in result.ranked_consensus.agree if s.selected]
+    print(f"  Polis (pick_max=5): {' '.join(polis_agree) if polis_agree else '(none)'}")
+    print(f"  Agora (BH fdr=0.10): {' '.join(agora_agree) if agora_agree else '(none)'}")
+
+    print()
+    print("--- Consensus (disagree) ---")
+    polis_disagree = [f"s{s['tid']}" for s in polis_consensus["disagree"]]
+    agora_disagree = [f"s{s.statement_id}" for s in result.ranked_consensus.disagree if s.selected]
+    print(f"  Polis (pick_max=5): {' '.join(polis_disagree) if polis_disagree else '(none)'}")
+    print(f"  Agora (BH fdr=0.10): {' '.join(agora_disagree) if agora_disagree else '(none)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cram/agora_snapshot.t
+++ b/tests/cram/agora_snapshot.t
@@ -1,0 +1,651 @@
+Agora pipeline snapshot test using small fixture data (below-100-ptpts).
+Shows representative opinions, group-aware consensus, consensus statements,
+and divisive statements with cross-group comparisons.
+
+  $ cd "$TESTDIR/../.."
+  $ uv run python scripts/print_agora_snapshot.py tests/fixtures/below-100-ptpts
+  === AGORA PIPELINE SNAPSHOT ===
+  Fixture: tests/fixtures/below-100-ptpts
+  Participants: 19 clustered, 3 groups
+  Statements: 42 active (2 moderated out)
+  
+  === REPRESENTATIVE OPINIONS ===
+  
+  --- Group 0 ---
+   #  Sel  Dir    Stmt  Effect  Text
+                                     G0 pa/pd (na/nd/ns) |  G1 pa/pd (na/nd/ns) |  G2 pa/pd (na/nd/ns)
+   1  [*]  dis    s13   4.8000  "Polis statements can be too si..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.91/0.09 ( 9/ 0/ 9)
+   2  [*]  agree  s1    4.4800  "The prominent display of divis..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.50 ( 0/ 2/ 4) |  0.20/0.40 ( 1/ 3/ 8)
+   3  [ ]  dis    s29   3.5556  "whether I engage through a tex..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.17/0.17 ( 0/ 0/ 4)
+   4  [ ]  dis    s34   3.5556  "It asks for my email once I’ve..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.67/0.17 ( 3/ 0/ 4)
+   5  [*]  dis    s9    3.4133  "Due to the 140 character limit..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.67/0.17 ( 7/ 1/10)
+   6  [*]  dis    s20   3.2000  "It's hard to communicate techn..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.33/0.17 ( 1/ 0/ 4) |  0.73/0.27 ( 7/ 2/ 9)
+   7  [ ]  dis    s27   2.7500  "I wish statements weren't limi..."
+                                     0.25/0.50 ( 0/ 1/ 2) |  0.20/0.20 ( 0/ 0/ 3) |  0.75/0.12 ( 5/ 0/ 6)
+   8  [ ]  dis    s35   2.6667  "Set a slightly higher characte..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.33/0.33 ( 0/ 0/ 1) |  0.60/0.20 ( 2/ 0/ 3)
+   9  [ ]  agree  s22   1.8000  "Polis relies on the participan..."
+                                     0.60/0.40 ( 2/ 1/ 3) |  0.33/0.33 ( 1/ 1/ 4) |  0.18/0.73 ( 1/ 7/ 9)
+  10  [ ]  agree  s8    1.7920  "Polis needs a way to showcase ..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.50/0.20 ( 4/ 1/ 8)
+  11  [ ]  agree  s5    1.7920  "Tooling for multiple moderator..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.50/0.10 ( 4/ 0/ 8)
+  12  [ ]  dis    s19   1.5300  "Polis feels too abstract and a..."
+                                     0.40/0.60 ( 1/ 2/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.77/0.23 ( 9/ 2/11)
+  13  [ ]  agree  s24   1.2800  "Polis needs to support transla..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.70/0.10 ( 6/ 0/ 8)
+  14  [ ]  agree  s16   1.2800  "It sucks that there's no way t..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.33/0.17 ( 1/ 0/ 4) |  0.58/0.25 ( 6/ 2/10)
+  15  [ ]  agree  s4    1.2000  "There's no way to review previ..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.73/0.27 ( 7/ 2/ 9)
+  16  [ ]  dis    s15   1.2000  "The inability to search for st..."
+                                     0.40/0.40 ( 1/ 1/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.45/0.18 ( 4/ 1/ 9)
+  17  [ ]  dis    s17   1.2000  "I have no way to communicate t..."
+                                     0.20/0.40 ( 0/ 1/ 3) |  0.29/0.29 ( 1/ 1/ 5) |  0.70/0.10 ( 6/ 0/ 8)
+  18  [ ]  agree  s23   1.1667  "There can be a bias against mi..."
+                                     0.50/0.50 ( 1/ 1/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.30/0.20 ( 2/ 1/ 8)
+  19  [ ]  agree  s14   1.1250  "Polis should have a "remind me..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.17/0.50 ( 0/ 2/ 4) |  0.67/0.08 ( 7/ 0/10)
+  20  [ ]  agree  s31   1.1250  "Nuance in Polis is created by ..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2)
+  21  [ ]  dis    s25   1.0080  "I want to be able to make a st..."
+                                     0.40/0.60 ( 1/ 2/ 3) |  0.17/0.50 ( 0/ 2/ 4) |  0.60/0.30 ( 5/ 2/ 8)
+  22  [ ]  agree  s18   0.9844  "I am worried bad actors can sw..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.33/0.17 ( 1/ 0/ 4) |  0.70/0.20 ( 6/ 1/ 8)
+  23  [ ]  dis    s21   0.9167  "I want to be able to share mor..."
+                                     0.50/0.50 ( 1/ 1/ 2) |  0.20/0.60 ( 0/ 2/ 3) |  0.75/0.12 ( 5/ 0/ 6)
+  24  [ ]  agree  s7    0.8750  "The Polis website is not compl..."
+                                     0.50/0.25 ( 1/ 0/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.40/0.20 ( 3/ 1/ 8)
+  25  [ ]  dis    s2    0.8750  "There's no way to differentiat..."
+                                     0.25/0.50 ( 0/ 1/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.60/0.30 ( 5/ 2/ 8)
+  26  [ ]  agree  s12   0.8750  "Polis is a very simple tool to..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.67/0.17 ( 3/ 0/ 4) |  0.60/0.20 ( 5/ 1/ 8)
+  27  [ ]  agree  s30   0.8438  "Polis statements are atomic/bi..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.67/0.33 ( 1/ 0/ 1) |  0.60/0.20 ( 2/ 0/ 3)
+  28  [ ]  dis    s0    0.7875  "Polis is perfect just the way ..."
+                                     0.25/0.75 ( 0/ 2/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.10/0.90 ( 0/ 8/ 8)
+  29  [ ]  agree  s26   0.7564  "I like how Polis relies on use..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.83/0.17 ( 4/ 0/ 4) |  0.78/0.11 ( 6/ 0/ 7)
+  30  [ ]  dis    s37   0.7500  "Admin option of setting a thre..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.67/0.33 ( 1/ 0/ 1)
+  31  [ ]  agree  s10   0.7467  "Comments should follow a narra..."
+                                     0.40/0.40 ( 1/ 1/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.30/0.30 ( 2/ 2/ 8)
+  32  [ ]  agree  s6    0.7200  "It's unclear if Polis' algorit..."
+                                     0.60/0.20 ( 2/ 0/ 3) |  0.29/0.43 ( 1/ 2/ 5) |  0.64/0.09 ( 6/ 0/ 9)
+  33  [ ]  agree  s32   0.6667  "There should be a QR code for ..."
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.75/0.25 ( 2/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2)
+  34  [ ]  agree  s36   0.6667  "Give participants feedback abo..."
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.75/0.25 ( 2/ 0/ 2)
+  35  [ ]  agree  s38   0.6222  "Fix log in"
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.80/0.20 ( 3/ 0/ 3)
+  36  [ ]  agree  s28   0.6188  "Questions that have been 'pass..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.75/0.25 ( 2/ 0/ 2) |  0.89/0.11 ( 7/ 0/ 7)
+  37  [ ]  agree  s3    0.5833  "Polis user-facing documentatio..."
+                                     0.50/0.25 ( 1/ 0/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.60/0.10 ( 5/ 0/ 8)
+  38  [ ]  agree  s42   0.5000  "There is no clear visual hiera..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  39  [ ]  agree  s39   0.5000  "testing if this works when i s..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  40  [ ]  agree  s40   0.5000  "Testing out screen reader to s..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  41  [ ]  agree  s41   0.5000  "the interface is lack of space..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  42  [ ]  agree  s43   0.5000  "test"
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  
+  --- Group 1 ---
+   #  Sel  Dir    Stmt  Effect  Text
+                                     G0 pa/pd (na/nd/ns) |  G1 pa/pd (na/nd/ns) |  G2 pa/pd (na/nd/ns)
+   1  [ ]  dis    s14   3.5000  "Polis should have a "remind me..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.17/0.50 ( 0/ 2/ 4) |  0.67/0.08 ( 7/ 0/10)
+   2  [ ]  dis    s6    2.5714  "It's unclear if Polis' algorit..."
+                                     0.60/0.20 ( 2/ 0/ 3) |  0.29/0.43 ( 1/ 2/ 5) |  0.64/0.09 ( 6/ 0/ 9)
+   3  [ ]  dis    s21   1.8000  "I want to be able to share mor..."
+                                     0.50/0.50 ( 1/ 1/ 2) |  0.20/0.60 ( 0/ 2/ 3) |  0.75/0.12 ( 5/ 0/ 6)
+   4  [ ]  agree  s29   1.7500  "whether I engage through a tex..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.17/0.17 ( 0/ 0/ 4)
+   5  [ ]  dis    s3    1.3333  "Polis user-facing documentatio..."
+                                     0.50/0.25 ( 1/ 0/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.60/0.10 ( 5/ 0/ 8)
+   6  [ ]  agree  s32   0.9375  "There should be a QR code for ..."
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.75/0.25 ( 2/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2)
+   7  [ ]  agree  s26   0.8333  "I like how Polis relies on use..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.83/0.17 ( 4/ 0/ 4) |  0.78/0.11 ( 6/ 0/ 7)
+   8  [ ]  dis    s1    0.8125  "The prominent display of divis..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.50 ( 0/ 2/ 4) |  0.20/0.40 ( 1/ 3/ 8)
+   9  [ ]  dis    s37   0.7500  "Admin option of setting a thre..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.67/0.33 ( 1/ 0/ 1)
+  10  [ ]  dis    s7    0.6667  "The Polis website is not compl..."
+                                     0.50/0.25 ( 1/ 0/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.40/0.20 ( 3/ 1/ 8)
+  11  [ ]  agree  s12   0.6667  "Polis is a very simple tool to..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.67/0.17 ( 3/ 0/ 4) |  0.60/0.20 ( 5/ 1/ 8)
+  12  [ ]  dis    s25   0.6500  "I want to be able to make a st..."
+                                     0.40/0.60 ( 1/ 2/ 3) |  0.17/0.50 ( 0/ 2/ 4) |  0.60/0.30 ( 5/ 2/ 8)
+  13  [ ]  agree  s30   0.6222  "Polis statements are atomic/bi..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.67/0.33 ( 1/ 0/ 1) |  0.60/0.20 ( 2/ 0/ 3)
+  14  [ ]  agree  s28   0.6188  "Questions that have been 'pass..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.75/0.25 ( 2/ 0/ 2) |  0.89/0.11 ( 7/ 0/ 7)
+  15  [ ]  dis    s17   0.5306  "I have no way to communicate t..."
+                                     0.20/0.40 ( 0/ 1/ 3) |  0.29/0.29 ( 1/ 1/ 5) |  0.70/0.10 ( 6/ 0/ 8)
+  16  [ ]  agree  s40   0.5000  "Testing out screen reader to s..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  17  [ ]  agree  s41   0.5000  "the interface is lack of space..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  18  [ ]  agree  s39   0.5000  "testing if this works when i s..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  19  [ ]  agree  s42   0.5000  "There is no clear visual hiera..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  20  [ ]  agree  s43   0.5000  "test"
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  21  [ ]  dis    s23   0.4444  "There can be a bias against mi..."
+                                     0.50/0.50 ( 1/ 1/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.30/0.20 ( 2/ 1/ 8)
+  22  [ ]  agree  s34   0.4375  "It asks for my email once I’ve..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.67/0.17 ( 3/ 0/ 4)
+  23  [ ]  agree  s22   0.3889  "Polis relies on the participan..."
+                                     0.60/0.40 ( 2/ 1/ 3) |  0.33/0.33 ( 1/ 1/ 4) |  0.18/0.73 ( 1/ 7/ 9)
+  24  [ ]  dis    s13   0.3889  "Polis statements can be too si..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.91/0.09 ( 9/ 0/ 9)
+  25  [ ]  agree  s31   0.3750  "Nuance in Polis is created by ..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2)
+  26  [ ]  dis    s24   0.3611  "Polis needs to support transla..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.70/0.10 ( 6/ 0/ 8)
+  27  [ ]  dis    s5    0.3611  "Tooling for multiple moderator..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.50/0.10 ( 4/ 0/ 8)
+  28  [ ]  dis    s10   0.3611  "Comments should follow a narra..."
+                                     0.40/0.40 ( 1/ 1/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.30/0.30 ( 2/ 2/ 8)
+  29  [ ]  dis    s19   0.3556  "Polis feels too abstract and a..."
+                                     0.40/0.60 ( 1/ 2/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.77/0.23 ( 9/ 2/11)
+  30  [ ]  dis    s9    0.3333  "Due to the 140 character limit..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.67/0.17 ( 7/ 1/10)
+  31  [ ]  dis    s35   0.3333  "Set a slightly higher characte..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.33/0.33 ( 0/ 0/ 1) |  0.60/0.20 ( 2/ 0/ 3)
+  32  [ ]  dis    s2    0.3333  "There's no way to differentiat..."
+                                     0.25/0.50 ( 0/ 1/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.60/0.30 ( 5/ 2/ 8)
+  33  [ ]  agree  s0    0.3333  "Polis is perfect just the way ..."
+                                     0.25/0.75 ( 0/ 2/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.10/0.90 ( 0/ 8/ 8)
+  34  [ ]  agree  s36   0.3125  "Give participants feedback abo..."
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.75/0.25 ( 2/ 0/ 2)
+  35  [ ]  agree  s38   0.3000  "Fix log in"
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.80/0.20 ( 3/ 0/ 3)
+  36  [ ]  dis    s27   0.2000  "I wish statements weren't limi..."
+                                     0.25/0.50 ( 0/ 1/ 2) |  0.20/0.20 ( 0/ 0/ 3) |  0.75/0.12 ( 5/ 0/ 6)
+  37  [ ]  agree  s20   0.1944  "It's hard to communicate techn..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.33/0.17 ( 1/ 0/ 4) |  0.73/0.27 ( 7/ 2/ 9)
+  38  [ ]  dis    s8    0.1806  "Polis needs a way to showcase ..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.50/0.20 ( 4/ 1/ 8)
+  39  [ ]  agree  s16   0.1667  "It sucks that there's no way t..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.33/0.17 ( 1/ 0/ 4) |  0.58/0.25 ( 6/ 2/10)
+  40  [ ]  dis    s18   0.1667  "I am worried bad actors can sw..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.33/0.17 ( 1/ 0/ 4) |  0.70/0.20 ( 6/ 1/ 8)
+  41  [ ]  dis    s4    0.1296  "There's no way to review previ..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.73/0.27 ( 7/ 2/ 9)
+  42  [ ]  agree  s15   0.0648  "The inability to search for st..."
+                                     0.40/0.40 ( 1/ 1/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.45/0.18 ( 4/ 1/ 9)
+  
+  --- Group 2 ---
+   #  Sel  Dir    Stmt  Effect  Text
+                                     G0 pa/pd (na/nd/ns) |  G1 pa/pd (na/nd/ns) |  G2 pa/pd (na/nd/ns)
+   1  [*]  agree  s13   7.4380  "Polis statements can be too si..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.91/0.09 ( 9/ 0/ 9)
+   2  [*]  agree  s9    4.0000  "Due to the 140 character limit..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.67/0.17 ( 7/ 1/10)
+   3  [*]  agree  s27   3.9375  "I wish statements weren't limi..."
+                                     0.25/0.50 ( 0/ 1/ 2) |  0.20/0.20 ( 0/ 0/ 3) |  0.75/0.12 ( 5/ 0/ 6)
+   4  [ ]  agree  s2    2.8800  "There's no way to differentiat..."
+                                     0.25/0.50 ( 0/ 1/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.60/0.30 ( 5/ 2/ 8)
+   5  [*]  agree  s19   2.6627  "Polis feels too abstract and a..."
+                                     0.40/0.60 ( 1/ 2/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.77/0.23 ( 9/ 2/11)
+   6  [*]  agree  s17   2.4500  "I have no way to communicate t..."
+                                     0.20/0.40 ( 0/ 1/ 3) |  0.29/0.29 ( 1/ 1/ 5) |  0.70/0.10 ( 6/ 0/ 8)
+   7  [*]  agree  s20   2.3802  "It's hard to communicate techn..."
+                                     0.20/0.80 ( 0/ 3/ 3) |  0.33/0.17 ( 1/ 0/ 4) |  0.73/0.27 ( 7/ 2/ 9)
+   8  [ ]  agree  s21   1.9688  "I want to be able to share mor..."
+                                     0.50/0.50 ( 1/ 1/ 2) |  0.20/0.60 ( 0/ 2/ 3) |  0.75/0.12 ( 5/ 0/ 6)
+   9  [ ]  agree  s25   1.6200  "I want to be able to make a st..."
+                                     0.40/0.60 ( 1/ 2/ 3) |  0.17/0.50 ( 0/ 2/ 4) |  0.60/0.30 ( 5/ 2/ 8)
+  10  [*]  dis    s0    1.6200  "Polis is perfect just the way ..."
+                                     0.25/0.75 ( 0/ 2/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.10/0.90 ( 0/ 8/ 8)
+  11  [ ]  dis    s22   1.5868  "Polis relies on the participan..."
+                                     0.60/0.40 ( 2/ 1/ 3) |  0.33/0.33 ( 1/ 1/ 4) |  0.18/0.73 ( 1/ 7/ 9)
+  12  [ ]  agree  s35   1.4400  "Set a slightly higher characte..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.33/0.33 ( 0/ 0/ 1) |  0.60/0.20 ( 2/ 0/ 3)
+  13  [ ]  agree  s3    1.4400  "Polis user-facing documentatio..."
+                                     0.50/0.25 ( 1/ 0/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.60/0.10 ( 5/ 0/ 8)
+  14  [ ]  agree  s4    1.1901  "There's no way to review previ..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.73/0.27 ( 7/ 2/ 9)
+  15  [ ]  agree  s14   1.1852  "Polis should have a "remind me..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.17/0.50 ( 0/ 2/ 4) |  0.67/0.08 ( 7/ 0/10)
+  16  [ ]  agree  s34   1.1111  "It asks for my email once I’ve..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.67/0.17 ( 3/ 0/ 4)
+  17  [ ]  agree  s24   1.1025  "Polis needs to support transla..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.70/0.10 ( 6/ 0/ 8)
+  18  [ ]  agree  s38   1.0667  "Fix log in"
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.80/0.20 ( 3/ 0/ 3)
+  19  [ ]  agree  s6    1.0124  "It's unclear if Polis' algorit..."
+                                     0.60/0.20 ( 2/ 0/ 3) |  0.29/0.43 ( 1/ 2/ 5) |  0.64/0.09 ( 6/ 0/ 9)
+  20  [ ]  agree  s18   0.9800  "I am worried bad actors can sw..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.33/0.17 ( 1/ 0/ 4) |  0.70/0.20 ( 6/ 1/ 8)
+  21  [*]  agree  s28   0.9481  "Questions that have been 'pass..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.75/0.25 ( 2/ 0/ 2) |  0.89/0.11 ( 7/ 0/ 7)
+  22  [ ]  agree  s36   0.9375  "Give participants feedback abo..."
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.75/0.25 ( 2/ 0/ 2)
+  23  [ ]  agree  s15   0.9298  "The inability to search for st..."
+                                     0.40/0.40 ( 1/ 1/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.45/0.18 ( 4/ 1/ 9)
+  24  [ ]  agree  s37   0.8889  "Admin option of setting a thre..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.67/0.33 ( 1/ 0/ 1)
+  25  [ ]  agree  s26   0.6806  "I like how Polis relies on use..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.83/0.17 ( 4/ 0/ 4) |  0.78/0.11 ( 6/ 0/ 7)
+  26  [ ]  agree  s7    0.6400  "The Polis website is not compl..."
+                                     0.50/0.25 ( 1/ 0/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.40/0.20 ( 3/ 1/ 8)
+  27  [ ]  agree  s16   0.6125  "It sucks that there's no way t..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.33/0.17 ( 1/ 0/ 4) |  0.58/0.25 ( 6/ 2/10)
+  28  [ ]  agree  s8    0.5625  "Polis needs a way to showcase ..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.50/0.20 ( 4/ 1/ 8)
+  29  [ ]  agree  s5    0.5625  "Tooling for multiple moderator..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.50/0.10 ( 4/ 0/ 8)
+  30  [ ]  agree  s41   0.5000  "the interface is lack of space..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  31  [ ]  agree  s39   0.5000  "testing if this works when i s..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  32  [ ]  agree  s40   0.5000  "Testing out screen reader to s..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  33  [ ]  agree  s43   0.5000  "test"
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  34  [ ]  agree  s42   0.5000  "There is no clear visual hiera..."
+                                     0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  35  [ ]  dis    s1    0.4800  "The prominent display of divis..."
+                                     0.80/0.20 ( 3/ 0/ 3) |  0.17/0.50 ( 0/ 2/ 4) |  0.20/0.40 ( 1/ 3/ 8)
+  36  [ ]  agree  s12   0.4800  "Polis is a very simple tool to..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.67/0.17 ( 3/ 0/ 4) |  0.60/0.20 ( 5/ 1/ 8)
+  37  [ ]  agree  s30   0.4500  "Polis statements are atomic/bi..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.67/0.33 ( 1/ 0/ 1) |  0.60/0.20 ( 2/ 0/ 3)
+  38  [ ]  agree  s10   0.4050  "Comments should follow a narra..."
+                                     0.40/0.40 ( 1/ 1/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.30/0.30 ( 2/ 2/ 8)
+  39  [ ]  agree  s31   0.3750  "Nuance in Polis is created by ..."
+                                     0.75/0.25 ( 2/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2)
+  40  [ ]  agree  s23   0.3600  "There can be a bias against mi..."
+                                     0.50/0.50 ( 1/ 1/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.30/0.20 ( 2/ 1/ 8)
+  41  [ ]  agree  s32   0.3125  "There should be a QR code for ..."
+                                     0.67/0.33 ( 1/ 0/ 1) |  0.75/0.25 ( 2/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2)
+  42  [ ]  agree  s29   0.0694  "whether I engage through a tex..."
+                                     0.33/0.67 ( 0/ 1/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.17/0.17 ( 0/ 0/ 4)
+  
+  === GROUP-AWARE CONSENSUS (AGREE) ===
+   #  Stmt  GAC     Text
+                            G0 pa (na/nd/ns) |  G1 pa (na/nd/ns) |  G2 pa (na/nd/ns)
+   1  s26   0.6748  "I like how Polis relies on use..."
+                            0.80 ( 3/ 0/ 3) |  0.83 ( 4/ 0/ 4) |  0.78 ( 6/ 0/ 7)
+   2  s28   0.6300  "Questions that have been 'pass..."
+                            0.75 ( 2/ 0/ 2) |  0.75 ( 2/ 0/ 2) |  0.89 ( 7/ 0/ 7)
+   3  s12   0.5313  "Polis is a very simple tool to..."
+                            0.75 ( 2/ 0/ 2) |  0.67 ( 3/ 0/ 4) |  0.60 ( 5/ 1/ 8)
+   4  s30   0.4932  "Polis statements are atomic/bi..."
+                            0.75 ( 2/ 0/ 2) |  0.67 ( 1/ 0/ 1) |  0.60 ( 2/ 0/ 3)
+   5  s38   0.4743  "Fix log in"
+                            0.67 ( 1/ 0/ 1) |  0.50 ( 1/ 0/ 2) |  0.80 ( 3/ 0/ 3)
+   6  s36   0.4543  "Give participants feedback abo..."
+                            0.67 ( 1/ 0/ 1) |  0.50 ( 1/ 0/ 2) |  0.75 ( 2/ 0/ 2)
+   7  s32   0.4543  "There should be a QR code for ..."
+                            0.67 ( 1/ 0/ 1) |  0.75 ( 2/ 0/ 2) |  0.50 ( 1/ 0/ 2)
+   8  s18   0.4440  "I am worried bad actors can sw..."
+                            0.75 ( 2/ 0/ 2) |  0.33 ( 1/ 0/ 4) |  0.70 ( 6/ 1/ 8)
+   9  s31   0.4293  "Nuance in Polis is created by ..."
+                            0.75 ( 2/ 0/ 2) |  0.50 ( 1/ 0/ 2) |  0.50 ( 1/ 0/ 2)
+  10  s16   0.4269  "It sucks that there's no way t..."
+                            0.80 ( 3/ 0/ 3) |  0.33 ( 1/ 0/ 4) |  0.58 ( 6/ 2/10)
+  11  s24   0.3826  "Polis needs to support transla..."
+                            0.80 ( 3/ 0/ 3) |  0.17 ( 0/ 0/ 4) |  0.70 ( 6/ 0/ 8)
+  12  s4    0.3609  "There's no way to review previ..."
+                            0.80 ( 3/ 0/ 3) |  0.17 ( 0/ 0/ 4) |  0.73 ( 7/ 2/ 9)
+  13  s6    0.3566  "It's unclear if Polis' algorit..."
+                            0.60 ( 2/ 0/ 3) |  0.29 ( 1/ 2/ 5) |  0.64 ( 6/ 0/ 9)
+  14  s5    0.3420  "Tooling for multiple moderator..."
+                            0.80 ( 3/ 0/ 3) |  0.17 ( 0/ 0/ 4) |  0.50 ( 4/ 0/ 8)
+  15  s8    0.3288  "Polis needs a way to showcase ..."
+                            0.80 ( 3/ 0/ 3) |  0.17 ( 0/ 0/ 4) |  0.50 ( 4/ 1/ 8)
+  16  s14   0.3060  "Polis should have a "remind me..."
+                            0.75 ( 2/ 0/ 2) |  0.17 ( 0/ 2/ 4) |  0.67 ( 7/ 0/10)
+  17  s37   0.3029  "Admin option of setting a thre..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.67 ( 1/ 0/ 1)
+  18  s34   0.2850  "It asks for my email once I’ve..."
+                            0.33 ( 0/ 1/ 1) |  0.50 ( 1/ 0/ 2) |  0.67 ( 3/ 0/ 4)
+  19  s3    0.2823  "Polis user-facing documentatio..."
+                            0.50 ( 1/ 0/ 2) |  0.17 ( 0/ 1/ 4) |  0.60 ( 5/ 0/ 8)
+  20  s39   0.2500  "testing if this works when i s..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+  21  s40   0.2500  "Testing out screen reader to s..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+  22  s41   0.2500  "the interface is lack of space..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+  23  s42   0.2500  "There is no clear visual hiera..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+  24  s43   0.2500  "test"
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+  25  s17   0.2489  "I have no way to communicate t..."
+                            0.20 ( 0/ 1/ 3) |  0.29 ( 1/ 1/ 5) |  0.70 ( 6/ 0/ 8)
+  26  s7    0.2371  "The Polis website is not compl..."
+                            0.50 ( 1/ 0/ 2) |  0.17 ( 0/ 1/ 4) |  0.40 ( 3/ 1/ 8)
+  27  s21   0.2359  "I want to be able to share mor..."
+                            0.50 ( 1/ 1/ 2) |  0.20 ( 0/ 2/ 3) |  0.75 ( 5/ 0/ 6)
+  28  s27   0.2359  "I wish statements weren't limi..."
+                            0.25 ( 0/ 1/ 2) |  0.20 ( 0/ 0/ 3) |  0.75 ( 5/ 0/ 6)
+  29  s15   0.2314  "The inability to search for st..."
+                            0.40 ( 1/ 1/ 3) |  0.17 ( 0/ 0/ 4) |  0.45 ( 4/ 1/ 9)
+  30  s35   0.2280  "Set a slightly higher characte..."
+                            0.33 ( 0/ 1/ 1) |  0.33 ( 0/ 0/ 1) |  0.60 ( 2/ 0/ 3)
+  31  s19   0.2191  "Polis feels too abstract and a..."
+                            0.40 ( 1/ 2/ 3) |  0.17 ( 0/ 1/ 4) |  0.77 ( 9/ 2/11)
+  32  s23   0.1882  "There can be a bias against mi..."
+                            0.50 ( 1/ 1/ 2) |  0.17 ( 0/ 1/ 4) |  0.30 ( 2/ 1/ 8)
+  33  s1    0.1857  "The prominent display of divis..."
+                            0.80 ( 3/ 0/ 3) |  0.17 ( 0/ 2/ 4) |  0.20 ( 1/ 3/ 8)
+  34  s20   0.1805  "It's hard to communicate techn..."
+                            0.20 ( 0/ 3/ 3) |  0.33 ( 1/ 0/ 4) |  0.73 ( 7/ 2/ 9)
+  35  s2    0.1800  "There's no way to differentiat..."
+                            0.25 ( 0/ 1/ 2) |  0.17 ( 0/ 1/ 4) |  0.60 ( 5/ 2/ 8)
+  36  s29   0.1795  "whether I engage through a tex..."
+                            0.33 ( 0/ 1/ 1) |  0.50 ( 1/ 0/ 2) |  0.17 ( 0/ 0/ 4)
+  37  s10   0.1776  "Comments should follow a narra..."
+                            0.40 ( 1/ 1/ 3) |  0.17 ( 0/ 1/ 4) |  0.30 ( 2/ 2/ 8)
+  38  s25   0.1776  "I want to be able to make a st..."
+                            0.40 ( 1/ 2/ 3) |  0.17 ( 0/ 2/ 4) |  0.60 ( 5/ 2/ 8)
+  39  s22   0.1583  "Polis relies on the participan..."
+                            0.60 ( 2/ 1/ 3) |  0.33 ( 1/ 1/ 4) |  0.18 ( 1/ 7/ 9)
+  40  s13   0.1543  "Polis statements can be too si..."
+                            0.20 ( 0/ 3/ 3) |  0.17 ( 0/ 1/ 4) |  0.91 ( 9/ 0/ 9)
+  41  s9    0.1352  "Due to the 140 character limit..."
+                            0.20 ( 0/ 3/ 3) |  0.17 ( 0/ 1/ 4) |  0.67 ( 7/ 1/10)
+  42  s0    0.0411  "Polis is perfect just the way ..."
+                            0.25 ( 0/ 2/ 2) |  0.17 ( 0/ 1/ 4) |  0.10 ( 0/ 8/ 8)
+  
+  === GROUP-AWARE CONSENSUS (DISAGREE) ===
+   #  Stmt  GAC     Text
+                            G0 pd (na/nd/ns) |  G1 pd (na/nd/ns) |  G2 pd (na/nd/ns)
+   1  s0    0.5021  "Polis is perfect just the way ..."
+                            0.75 ( 0/ 2/ 2) |  0.33 ( 0/ 1/ 4) |  0.90 ( 0/ 8/ 8)
+   2  s22   0.2766  "Polis relies on the participan..."
+                            0.40 ( 2/ 1/ 3) |  0.33 ( 1/ 1/ 4) |  0.73 ( 1/ 7/ 9)
+   3  s25   0.2621  "I want to be able to make a st..."
+                            0.60 ( 1/ 2/ 3) |  0.50 ( 0/ 2/ 4) |  0.30 ( 5/ 2/ 8)
+   4  s39   0.2500  "testing if this works when i s..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+   5  s40   0.2500  "Testing out screen reader to s..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+   6  s41   0.2500  "the interface is lack of space..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+   7  s42   0.2500  "There is no clear visual hiera..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+   8  s43   0.2500  "test"
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0)
+   9  s10   0.2410  "Comments should follow a narra..."
+                            0.40 ( 1/ 1/ 3) |  0.33 ( 0/ 1/ 4) |  0.30 ( 2/ 2/ 8)
+  10  s2    0.2321  "There's no way to differentiat..."
+                            0.50 ( 0/ 1/ 2) |  0.33 ( 0/ 1/ 4) |  0.30 ( 5/ 2/ 8)
+  11  s9    0.2146  "Due to the 140 character limit..."
+                            0.80 ( 0/ 3/ 3) |  0.33 ( 0/ 1/ 4) |  0.17 ( 7/ 1/10)
+  12  s23   0.2134  "There can be a bias against mi..."
+                            0.50 ( 1/ 1/ 2) |  0.33 ( 0/ 1/ 4) |  0.20 ( 2/ 1/ 8)
+  13  s35   0.1992  "Set a slightly higher characte..."
+                            0.67 ( 0/ 1/ 1) |  0.33 ( 0/ 0/ 1) |  0.20 ( 2/ 0/ 3)
+  14  s29   0.1976  "whether I engage through a tex..."
+                            0.67 ( 0/ 1/ 1) |  0.25 ( 1/ 0/ 2) |  0.17 ( 0/ 0/ 4)
+  15  s37   0.1908  "Admin option of setting a thre..."
+                            0.50 ( 0/ 0/ 0) |  0.50 ( 0/ 0/ 0) |  0.33 ( 1/ 0/ 1)
+  16  s1    0.1747  "The prominent display of divis..."
+                            0.20 ( 3/ 0/ 3) |  0.50 ( 0/ 2/ 4) |  0.40 ( 1/ 3/ 8)
+  17  s19   0.1746  "Polis feels too abstract and a..."
+                            0.60 ( 1/ 2/ 3) |  0.33 ( 0/ 1/ 4) |  0.23 ( 9/ 2/11)
+  18  s20   0.1742  "It's hard to communicate techn..."
+                            0.80 ( 0/ 3/ 3) |  0.17 ( 1/ 0/ 4) |  0.27 ( 7/ 2/ 9)
+  19  s7    0.1609  "The Polis website is not compl..."
+                            0.25 ( 1/ 0/ 2) |  0.33 ( 0/ 1/ 4) |  0.20 ( 3/ 1/ 8)
+  20  s21   0.1554  "I want to be able to share mor..."
+                            0.50 ( 1/ 1/ 2) |  0.60 ( 0/ 2/ 3) |  0.12 ( 5/ 0/ 6)
+  21  s15   0.1490  "The inability to search for st..."
+                            0.40 ( 1/ 1/ 3) |  0.17 ( 0/ 0/ 4) |  0.18 ( 4/ 1/ 9)
+  22  s34   0.1456  "It asks for my email once I’ve..."
+                            0.67 ( 0/ 1/ 1) |  0.25 ( 1/ 0/ 2) |  0.17 ( 3/ 0/ 4)
+  23  s17   0.1251  "I have no way to communicate t..."
+                            0.40 ( 0/ 1/ 3) |  0.29 ( 1/ 1/ 5) |  0.10 ( 6/ 0/ 8)
+  24  s27   0.1233  "I wish statements weren't limi..."
+                            0.50 ( 0/ 1/ 2) |  0.20 ( 0/ 0/ 3) |  0.12 ( 5/ 0/ 6)
+  25  s13   0.1137  "Polis statements can be too si..."
+                            0.80 ( 0/ 3/ 3) |  0.33 ( 0/ 1/ 4) |  0.09 ( 9/ 0/ 9)
+  26  s3    0.1116  "Polis user-facing documentatio..."
+                            0.25 ( 1/ 0/ 2) |  0.33 ( 0/ 1/ 4) |  0.10 ( 5/ 0/ 8)
+  27  s31   0.0992  "Nuance in Polis is created by ..."
+                            0.25 ( 2/ 0/ 2) |  0.25 ( 1/ 0/ 2) |  0.25 ( 1/ 0/ 2)
+  28  s32   0.0954  "There should be a QR code for ..."
+                            0.33 ( 1/ 0/ 1) |  0.25 ( 2/ 0/ 2) |  0.25 ( 1/ 0/ 2)
+  29  s36   0.0954  "Give participants feedback abo..."
+                            0.33 ( 1/ 0/ 1) |  0.25 ( 1/ 0/ 2) |  0.25 ( 2/ 0/ 2)
+  30  s6    0.0932  "It's unclear if Polis' algorit..."
+                            0.20 ( 2/ 0/ 3) |  0.43 ( 1/ 2/ 5) |  0.09 ( 6/ 0/ 9)
+  31  s14   0.0898  "Polis should have a "remind me..."
+                            0.25 ( 2/ 0/ 2) |  0.50 ( 0/ 2/ 4) |  0.08 ( 7/ 0/10)
+  32  s30   0.0822  "Polis statements are atomic/bi..."
+                            0.25 ( 2/ 0/ 2) |  0.33 ( 1/ 0/ 1) |  0.20 ( 2/ 0/ 3)
+  33  s8    0.0822  "Polis needs a way to showcase ..."
+                            0.20 ( 3/ 0/ 3) |  0.17 ( 0/ 0/ 4) |  0.20 ( 4/ 1/ 8)
+  34  s38   0.0822  "Fix log in"
+                            0.33 ( 1/ 0/ 1) |  0.25 ( 1/ 0/ 2) |  0.20 ( 3/ 0/ 3)
+  35  s16   0.0774  "It sucks that there's no way t..."
+                            0.20 ( 3/ 0/ 3) |  0.17 ( 1/ 0/ 4) |  0.25 ( 6/ 2/10)
+  36  s18   0.0747  "I am worried bad actors can sw..."
+                            0.25 ( 2/ 0/ 2) |  0.17 ( 1/ 0/ 4) |  0.20 ( 6/ 1/ 8)
+  37  s4    0.0745  "There's no way to review previ..."
+                            0.20 ( 3/ 0/ 3) |  0.17 ( 0/ 0/ 4) |  0.27 ( 7/ 2/ 9)
+  38  s5    0.0652  "Tooling for multiple moderator..."
+                            0.20 ( 3/ 0/ 3) |  0.17 ( 0/ 0/ 4) |  0.10 ( 4/ 0/ 8)
+  39  s12   0.0652  "Polis is a very simple tool to..."
+                            0.25 ( 2/ 0/ 2) |  0.17 ( 3/ 0/ 4) |  0.20 ( 5/ 1/ 8)
+  40  s24   0.0550  "Polis needs to support transla..."
+                            0.20 ( 3/ 0/ 3) |  0.17 ( 0/ 0/ 4) |  0.10 ( 6/ 0/ 8)
+  41  s28   0.0364  "Questions that have been 'pass..."
+                            0.25 ( 2/ 0/ 2) |  0.25 ( 2/ 0/ 2) |  0.11 ( 7/ 0/ 7)
+  42  s26   0.0302  "I like how Polis relies on use..."
+                            0.20 ( 3/ 0/ 3) |  0.17 ( 4/ 0/ 4) |  0.11 ( 6/ 0/ 7)
+  
+  === CONSENSUS STATEMENTS (AGREE) ===
+   #  Sel  Stmt  Effect  pa    na/nd/ns  p_adj    Text
+   1  [*]  s26   0.8889  0.89  15/ 0/16  0.0058  "I like how Polis relies on use..."
+   2  [*]  s28   0.8750  0.88  13/ 1/14  0.0083  "Questions that have been 'pass..."
+   3  [ ]  s32   0.7500  0.75   5/ 0/ 6  0.2359  "There should be a QR code for ..."
+   4  [ ]  s30   0.7273  0.73   7/ 1/ 9  0.2359  "Polis statements are atomic/bi..."
+   5  [ ]  s42   0.6667  0.67   1/ 0/ 1  0.2359  "There is no clear visual hiera..."
+   6  [ ]  s36   0.6667  0.67   5/ 0/ 7  0.2359  "Give participants feedback abo..."
+   7  [ ]  s43   0.6667  0.67   1/ 0/ 1  0.2359  "test"
+   8  [ ]  s38   0.6667  0.67   5/ 1/ 7  0.2359  "Fix log in"
+   9  [ ]  s39   0.6667  0.67   1/ 0/ 1  0.2359  "testing if this works when i s..."
+  10  [ ]  s40   0.6667  0.67   1/ 0/ 1  0.2359  "Testing out screen reader to s..."
+  11  [ ]  s41   0.6667  0.67   1/ 0/ 1  0.2359  "the interface is lack of space..."
+  12  [ ]  s37   0.6667  0.67   1/ 0/ 1  0.2359  "Admin option of setting a thre..."
+  13  [ ]  s18   0.6667  0.67  11/ 1/16  0.2359  "I am worried bad actors can sw..."
+  14  [ ]  s12   0.6471  0.65  10/ 2/15  0.2359  "Polis is a very simple tool to..."
+  15  [ ]  s4    0.6111  0.61  10/ 2/16  0.3154  "There's no way to review previ..."
+  16  [ ]  s24   0.5882  0.59   9/ 0/15  0.4165  "Polis needs to support transla..."
+  17  [ ]  s16   0.5714  0.57  11/ 2/19  0.4584  "It sucks that there's no way t..."
+  18  [ ]  s21   0.5625  0.56   8/ 4/14  0.4690  "I want to be able to share mor..."
+  19  [ ]  s34   0.5556  0.56   4/ 1/ 7  0.4690  "It asks for my email once I’ve..."
+  20  [ ]  s14   0.5556  0.56   9/ 2/16  0.4690  "Polis should have a "remind me..."
+  21  [ ]  s13   0.5556  0.56   9/ 4/16  0.4690  "Polis statements can be too si..."
+  22  [ ]  s19   0.5500  0.55  10/ 5/18  0.4690  "Polis feels too abstract and a..."
+  23  [ ]  s31   0.5455  0.55   5/ 0/ 9  0.4813  "Nuance in Polis is created by ..."
+  24  [ ]  s6    0.5263  0.53   9/ 2/17  0.5577  "It's unclear if Polis' algorit..."
+  25  [ ]  s20   0.5000  0.50   8/ 5/16  0.6529  "It's hard to communicate techn..."
+  26  [ ]  s27   0.5000  0.50   6/ 1/12  0.6529  "I wish statements weren't limi..."
+  27  [ ]  s5    0.4706  0.47   7/ 0/15  0.7500  "Tooling for multiple moderator..."
+  28  [ ]  s8    0.4706  0.47   7/ 1/15  0.7500  "Polis needs a way to showcase ..."
+  29  [ ]  s9    0.4500  0.45   8/ 5/18  0.8072  "Due to the 140 character limit..."
+  30  [ ]  s17   0.4444  0.44   7/ 2/16  0.8072  "I have no way to communicate t..."
+  31  [ ]  s25   0.4444  0.44   7/ 6/16  0.8072  "I want to be able to make a st..."
+  32  [ ]  s3    0.4118  0.41   6/ 2/15  0.8800  "Polis user-facing documentatio..."
+  33  [ ]  s35   0.3750  0.38   2/ 1/ 6  0.8495  "Set a slightly higher characte..."
+  34  [ ]  s2    0.3750  0.38   5/ 4/14  0.9369  "There's no way to differentiat..."
+  35  [ ]  s29   0.3636  0.36   3/ 1/ 9  0.9097  "whether I engage through a tex..."
+  36  [ ]  s15   0.3333  0.33   5/ 2/16  0.9996  "The inability to search for st..."
+  37  [ ]  s7    0.3125  0.31   4/ 2/14  0.9996  "The Polis website is not compl..."
+  38  [ ]  s1    0.2941  0.29   4/ 5/15  0.9996  "The prominent display of divis..."
+  39  [ ]  s22   0.2778  0.28   4/ 9/16  0.9996  "Polis relies on the participan..."
+  40  [ ]  s23   0.2500  0.25   3/ 3/14  0.9996  "There can be a bias against mi..."
+  41  [ ]  s10   0.2353  0.24   3/ 4/15  0.9996  "Comments should follow a narra..."
+  42  [ ]  s0    0.0625  0.06   0/11/14  0.9996  "Polis is perfect just the way ..."
+  
+  === CONSENSUS STATEMENTS (DISAGREE) ===
+   #  Sel  Stmt  Effect  pd    na/nd/ns  p_adj    Text
+   1  [ ]  s0    0.7500  0.75   0/11/14  0.4229  "Polis is perfect just the way ..."
+   2  [ ]  s22   0.5556  0.56   4/ 9/16  0.9999  "Polis relies on the participan..."
+   3  [ ]  s25   0.3889  0.39   7/ 6/16  0.9999  "I want to be able to make a st..."
+   4  [ ]  s1    0.3529  0.35   4/ 5/15  0.9999  "The prominent display of divis..."
+   5  [ ]  s41   0.3333  0.33   1/ 0/ 1  0.9999  "the interface is lack of space..."
+   6  [ ]  s40   0.3333  0.33   1/ 0/ 1  0.9999  "Testing out screen reader to s..."
+   7  [ ]  s39   0.3333  0.33   1/ 0/ 1  0.9999  "testing if this works when i s..."
+   8  [ ]  s37   0.3333  0.33   1/ 0/ 1  0.9999  "Admin option of setting a thre..."
+   9  [ ]  s42   0.3333  0.33   1/ 0/ 1  0.9999  "There is no clear visual hiera..."
+  10  [ ]  s20   0.3333  0.33   8/ 5/16  0.9999  "It's hard to communicate techn..."
+  11  [ ]  s43   0.3333  0.33   1/ 0/ 1  0.9999  "test"
+  12  [ ]  s21   0.3125  0.31   8/ 4/14  0.9999  "I want to be able to share mor..."
+  13  [ ]  s2    0.3125  0.31   5/ 4/14  0.9999  "There's no way to differentiat..."
+  14  [ ]  s19   0.3000  0.30  10/ 5/18  0.9999  "Polis feels too abstract and a..."
+  15  [ ]  s9    0.3000  0.30   8/ 5/18  0.9999  "Due to the 140 character limit..."
+  16  [ ]  s10   0.2941  0.29   3/ 4/15  0.9999  "Comments should follow a narra..."
+  17  [ ]  s13   0.2778  0.28   9/ 4/16  0.9999  "Polis statements can be too si..."
+  18  [ ]  s35   0.2500  0.25   2/ 1/ 6  0.9999  "Set a slightly higher characte..."
+  19  [ ]  s23   0.2500  0.25   3/ 3/14  0.9999  "There can be a bias against mi..."
+  20  [ ]  s38   0.2222  0.22   5/ 1/ 7  0.9999  "Fix log in"
+  21  [ ]  s34   0.2222  0.22   4/ 1/ 7  0.9999  "It asks for my email once I’ve..."
+  22  [ ]  s7    0.1875  0.19   4/ 2/14  0.9999  "The Polis website is not compl..."
+  23  [ ]  s30   0.1818  0.18   7/ 1/ 9  0.9999  "Polis statements are atomic/bi..."
+  24  [ ]  s29   0.1818  0.18   3/ 1/ 9  0.9999  "whether I engage through a tex..."
+  25  [ ]  s3    0.1765  0.18   6/ 2/15  0.9999  "Polis user-facing documentatio..."
+  26  [ ]  s12   0.1765  0.18  10/ 2/15  0.9999  "Polis is a very simple tool to..."
+  27  [ ]  s17   0.1667  0.17   7/ 2/16  0.9999  "I have no way to communicate t..."
+  28  [ ]  s4    0.1667  0.17  10/ 2/16  0.9999  "There's no way to review previ..."
+  29  [ ]  s15   0.1667  0.17   5/ 2/16  0.9999  "The inability to search for st..."
+  30  [ ]  s14   0.1667  0.17   9/ 2/16  0.9999  "Polis should have a "remind me..."
+  31  [ ]  s6    0.1579  0.16   9/ 2/17  0.9999  "It's unclear if Polis' algorit..."
+  32  [ ]  s16   0.1429  0.14  11/ 2/19  0.9999  "It sucks that there's no way t..."
+  33  [ ]  s27   0.1429  0.14   6/ 1/12  0.9999  "I wish statements weren't limi..."
+  34  [ ]  s28   0.1250  0.12  13/ 1/14  0.9999  "Questions that have been 'pass..."
+  35  [ ]  s32   0.1250  0.12   5/ 0/ 6  0.9999  "There should be a QR code for ..."
+  36  [ ]  s8    0.1176  0.12   7/ 1/15  0.9999  "Polis needs a way to showcase ..."
+  37  [ ]  s18   0.1111  0.11  11/ 1/16  0.9999  "I am worried bad actors can sw..."
+  38  [ ]  s36   0.1111  0.11   5/ 0/ 7  0.9999  "Give participants feedback abo..."
+  39  [ ]  s31   0.0909  0.09   5/ 0/ 9  0.9999  "Nuance in Polis is created by ..."
+  40  [ ]  s24   0.0588  0.06   9/ 0/15  0.9999  "Polis needs to support transla..."
+  41  [ ]  s5    0.0588  0.06   7/ 0/15  0.9999  "Tooling for multiple moderator..."
+  42  [ ]  s26   0.0556  0.06  15/ 0/16  0.9999  "I like how Polis relies on use..."
+  
+  === DIVISIVE STATEMENTS ===
+   #  Stmt  Div     Text
+                            G0 pa/pd (na/nd/ns) |  G1 pa/pd (na/nd/ns) |  G2 pa/pd (na/nd/ns)
+   1  s13   0.7424  "Polis statements can be too si..."
+                            0.20/0.80 ( 0/ 3/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.91/0.09 ( 9/ 0/ 9)
+   2  s1    0.6333  "The prominent display of divis..."
+                            0.80/0.20 ( 3/ 0/ 3) |  0.17/0.50 ( 0/ 2/ 4) |  0.20/0.40 ( 1/ 3/ 8)
+   3  s4    0.6333  "There's no way to review previ..."
+                            0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.73/0.27 ( 7/ 2/ 9)
+   4  s5    0.6333  "Tooling for multiple moderator..."
+                            0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.50/0.10 ( 4/ 0/ 8)
+   5  s8    0.6333  "Polis needs a way to showcase ..."
+                            0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.50/0.20 ( 4/ 1/ 8)
+   6  s24   0.6333  "Polis needs to support transla..."
+                            0.80/0.20 ( 3/ 0/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.70/0.10 ( 6/ 0/ 8)
+   7  s19   0.6026  "Polis feels too abstract and a..."
+                            0.40/0.60 ( 1/ 2/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.77/0.23 ( 9/ 2/11)
+   8  s14   0.5833  "Polis should have a "remind me..."
+                            0.75/0.25 ( 2/ 0/ 2) |  0.17/0.50 ( 0/ 2/ 4) |  0.67/0.08 ( 7/ 0/10)
+   9  s21   0.5500  "I want to be able to share mor..."
+                            0.50/0.50 ( 1/ 1/ 2) |  0.20/0.60 ( 0/ 2/ 3) |  0.75/0.12 ( 5/ 0/ 6)
+  10  s27   0.5500  "I wish statements weren't limi..."
+                            0.25/0.50 ( 0/ 1/ 2) |  0.20/0.20 ( 0/ 0/ 3) |  0.75/0.12 ( 5/ 0/ 6)
+  11  s20   0.5273  "It's hard to communicate techn..."
+                            0.20/0.80 ( 0/ 3/ 3) |  0.33/0.17 ( 1/ 0/ 4) |  0.73/0.27 ( 7/ 2/ 9)
+  12  s9    0.5000  "Due to the 140 character limit..."
+                            0.20/0.80 ( 0/ 3/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.67/0.17 ( 7/ 1/10)
+  13  s17   0.5000  "I have no way to communicate t..."
+                            0.20/0.40 ( 0/ 1/ 3) |  0.29/0.29 ( 1/ 1/ 5) |  0.70/0.10 ( 6/ 0/ 8)
+  14  s16   0.4667  "It sucks that there's no way t..."
+                            0.80/0.20 ( 3/ 0/ 3) |  0.33/0.17 ( 1/ 0/ 4) |  0.58/0.25 ( 6/ 2/10)
+  15  s2    0.4333  "There's no way to differentiat..."
+                            0.25/0.50 ( 0/ 1/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.60/0.30 ( 5/ 2/ 8)
+  16  s3    0.4333  "Polis user-facing documentatio..."
+                            0.50/0.25 ( 1/ 0/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.60/0.10 ( 5/ 0/ 8)
+  17  s25   0.4333  "I want to be able to make a st..."
+                            0.40/0.60 ( 1/ 2/ 3) |  0.17/0.50 ( 0/ 2/ 4) |  0.60/0.30 ( 5/ 2/ 8)
+  18  s22   0.4182  "Polis relies on the participan..."
+                            0.60/0.40 ( 2/ 1/ 3) |  0.33/0.33 ( 1/ 1/ 4) |  0.18/0.73 ( 1/ 7/ 9)
+  19  s18   0.4167  "I am worried bad actors can sw..."
+                            0.75/0.25 ( 2/ 0/ 2) |  0.33/0.17 ( 1/ 0/ 4) |  0.70/0.20 ( 6/ 1/ 8)
+  20  s6    0.3506  "It's unclear if Polis' algorit..."
+                            0.60/0.20 ( 2/ 0/ 3) |  0.29/0.43 ( 1/ 2/ 5) |  0.64/0.09 ( 6/ 0/ 9)
+  21  s7    0.3333  "The Polis website is not compl..."
+                            0.50/0.25 ( 1/ 0/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.40/0.20 ( 3/ 1/ 8)
+  22  s23   0.3333  "There can be a bias against mi..."
+                            0.50/0.50 ( 1/ 1/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.30/0.20 ( 2/ 1/ 8)
+  23  s29   0.3333  "whether I engage through a tex..."
+                            0.33/0.67 ( 0/ 1/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.17/0.17 ( 0/ 0/ 4)
+  24  s34   0.3333  "It asks for my email once I’ve..."
+                            0.33/0.67 ( 0/ 1/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.67/0.17 ( 3/ 0/ 4)
+  25  s38   0.3000  "Fix log in"
+                            0.67/0.33 ( 1/ 0/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.80/0.20 ( 3/ 0/ 3)
+  26  s15   0.2879  "The inability to search for st..."
+                            0.40/0.40 ( 1/ 1/ 3) |  0.17/0.17 ( 0/ 0/ 4) |  0.45/0.18 ( 4/ 1/ 9)
+  27  s35   0.2667  "Set a slightly higher characte..."
+                            0.33/0.67 ( 0/ 1/ 1) |  0.33/0.33 ( 0/ 0/ 1) |  0.60/0.20 ( 2/ 0/ 3)
+  28  s31   0.2500  "Nuance in Polis is created by ..."
+                            0.75/0.25 ( 2/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2)
+  29  s32   0.2500  "There should be a QR code for ..."
+                            0.67/0.33 ( 1/ 0/ 1) |  0.75/0.25 ( 2/ 0/ 2) |  0.50/0.25 ( 1/ 0/ 2)
+  30  s36   0.2500  "Give participants feedback abo..."
+                            0.67/0.33 ( 1/ 0/ 1) |  0.50/0.25 ( 1/ 0/ 2) |  0.75/0.25 ( 2/ 0/ 2)
+  31  s10   0.2333  "Comments should follow a narra..."
+                            0.40/0.40 ( 1/ 1/ 3) |  0.17/0.33 ( 0/ 1/ 4) |  0.30/0.30 ( 2/ 2/ 8)
+  32  s37   0.1667  "Admin option of setting a thre..."
+                            0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.67/0.33 ( 1/ 0/ 1)
+  33  s12   0.1500  "Polis is a very simple tool to..."
+                            0.75/0.25 ( 2/ 0/ 2) |  0.67/0.17 ( 3/ 0/ 4) |  0.60/0.20 ( 5/ 1/ 8)
+  34  s30   0.1500  "Polis statements are atomic/bi..."
+                            0.75/0.25 ( 2/ 0/ 2) |  0.67/0.33 ( 1/ 0/ 1) |  0.60/0.20 ( 2/ 0/ 3)
+  35  s0    0.1500  "Polis is perfect just the way ..."
+                            0.25/0.75 ( 0/ 2/ 2) |  0.17/0.33 ( 0/ 1/ 4) |  0.10/0.90 ( 0/ 8/ 8)
+  36  s28   0.1389  "Questions that have been 'pass..."
+                            0.75/0.25 ( 2/ 0/ 2) |  0.75/0.25 ( 2/ 0/ 2) |  0.89/0.11 ( 7/ 0/ 7)
+  37  s26   0.0556  "I like how Polis relies on use..."
+                            0.80/0.20 ( 3/ 0/ 3) |  0.83/0.17 ( 4/ 0/ 4) |  0.78/0.11 ( 6/ 0/ 7)
+  38  s39   0.0000  "testing if this works when i s..."
+                            0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  39  s40   0.0000  "Testing out screen reader to s..."
+                            0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  40  s41   0.0000  "the interface is lack of space..."
+                            0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  41  s42   0.0000  "There is no clear visual hiera..."
+                            0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  42  s43   0.0000  "test"
+                            0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0) |  0.50/0.50 ( 0/ 0/ 0)
+  
+  === SELECTION COMPARISON ===
+  
+  --- Repness ---
+  Group 0:
+    Polis (pick_max=5): s1(a) s13(d) s9(d) s20(d) s29(d)
+    Agora (BH fdr=0.10): s13(d) s1(a) s9(d) s20(d)
+  Group 1:
+    Polis (pick_max=5): s26(a)
+    Agora (BH fdr=0.10): (none)
+  Group 2:
+    Polis (pick_max=5): s13(a) s27(a) s19(a) s9(a) s0(d)
+    Agora (BH fdr=0.10): s13(a) s9(a) s27(a) s19(a) s17(a) s20(a) s0(d) s28(a)
+  
+  --- Consensus (agree) ---
+    Polis (pick_max=5): s26 s28 s32 s30 s18
+    Agora (BH fdr=0.10): s26 s28
+  
+  --- Consensus (disagree) ---
+    Polis (pick_max=5): s0
+    Agora (BH fdr=0.10): (none)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -236,6 +236,25 @@ def polis_gac_to_geometric_mean(n_groups, polis_gac):
     }
 
 
+def compute_expected_gac(grouped_stats_df, statement_ids, n_groups):
+    """
+    Compute expected group-aware consensus using effective agreement formula.
+
+    Uses: prod(pa * (1 - pd))^(1/n_groups) per statement across all groups.
+    This matches the DIVERGENCE FROM POLIS in calculate_comment_statistics.
+    """
+    import pandas as pd
+    expected = {}
+    for statement_id in statement_ids:
+        effective_agree_product = 1.0
+        for gid in range(n_groups):
+            pa = grouped_stats_df.loc[(gid, statement_id), "pa"]
+            pd_val = grouped_stats_df.loc[(gid, statement_id), "pd"]
+            effective_agree_product *= pa * (1 - pd_val)
+        expected[statement_id] = effective_agree_product ** (1.0 / n_groups)
+    return expected
+
+
 class ReportType(Enum):
     SUMMARY = "summary"
     VOTES = "votes"

--- a/tests/utils/test_agora_stats.py
+++ b/tests/utils/test_agora_stats.py
@@ -1,0 +1,348 @@
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.testing import assert_array_equal
+
+from reddwarf.utils.stats import (
+    benjamini_hochberg,
+    calculate_comment_statistics_dataframes,
+    rank_representative_statements,
+    z_to_pvalue,
+)
+from reddwarf.utils.consensus import rank_consensus_statements
+from reddwarf.implementations.agora import compute_effective_agreement_gac
+
+
+# --- z_to_pvalue ---
+
+
+def test_z_to_pvalue_zero():
+    assert z_to_pvalue(0.0) == pytest.approx(0.5)
+
+
+def test_z_to_pvalue_large_positive():
+    p = z_to_pvalue(5.0)
+    assert p < 1e-5
+
+
+def test_z_to_pvalue_negative():
+    p = z_to_pvalue(-2.0)
+    assert p > 0.5
+
+
+def test_z_to_pvalue_array():
+    result = z_to_pvalue(np.array([0.0, 5.0, -2.0]))
+    assert result[0] == pytest.approx(0.5)
+    assert result[1] < 1e-5
+    assert result[2] > 0.5
+
+
+# --- benjamini_hochberg ---
+
+
+def test_benjamini_hochberg_basic():
+    # 5 hypotheses, first 2 have small p-values
+    p_values = np.array([0.001, 0.01, 0.3, 0.5, 0.9])
+    selected = benjamini_hochberg(p_values, fdr_rate=0.10)
+    # First two should be selected
+    assert selected[0] == True
+    assert selected[1] == True
+    # Rest should not
+    assert selected[2] == False
+    assert selected[3] == False
+    assert selected[4] == False
+
+
+def test_benjamini_hochberg_empty():
+    result = benjamini_hochberg(np.array([]), fdr_rate=0.10)
+    assert len(result) == 0
+
+
+def test_benjamini_hochberg_all_significant():
+    p_values = np.array([0.001, 0.002, 0.003, 0.004])
+    selected = benjamini_hochberg(p_values, fdr_rate=0.10)
+    assert all(selected)
+
+
+def test_benjamini_hochberg_none_significant():
+    p_values = np.array([0.5, 0.6, 0.7, 0.8])
+    selected = benjamini_hochberg(p_values, fdr_rate=0.10)
+    assert not any(selected)
+
+
+def test_benjamini_hochberg_adapts_to_size():
+    """With many hypotheses, BH should be more conservative than a fixed threshold."""
+    rng = np.random.default_rng(42)
+    # 1000 p-values, 50 truly significant (very small) + 950 null (uniform)
+    p_true = rng.uniform(1e-8, 1e-4, size=50)
+    p_null = rng.uniform(0.05, 1.0, size=950)
+    p_values = np.concatenate([p_true, p_null])
+
+    selected_bh = benjamini_hochberg(p_values, fdr_rate=0.10)
+    # Fixed threshold at 0.05 would select everything below 0.05
+    selected_fixed = p_values < 0.05
+
+    # BH should select fewer (or equal) than fixed threshold
+    assert selected_bh.sum() <= selected_fixed.sum()
+    # BH should still find some of the truly significant ones
+    assert selected_bh.sum() > 0
+
+
+# --- rank_representative_statements ---
+
+
+def _make_grouped_stats_df():
+    """Create a synthetic grouped_stats_df for testing rank functions."""
+    # 2 groups, 3 statements
+    data = []
+    # Group 0: statement 0 strongly agree-rep, statement 1 weakly, statement 2 disagree-rep
+    data.append({
+        "group_id": 0, "statement_id": 0,
+        "na": 8, "nd": 1, "ns": 10,
+        "pa": 0.75, "pd": 0.15, "pat": 3.0, "pdt": -1.5,
+        "ra": 1.8, "rd": 0.3, "rat": 4.0, "rdt": -2.0,
+    })
+    data.append({
+        "group_id": 0, "statement_id": 1,
+        "na": 5, "nd": 3, "ns": 10,
+        "pa": 0.55, "pd": 0.35, "pat": 0.5, "pdt": -0.2,
+        "ra": 1.1, "rd": 0.9, "rat": 0.3, "rdt": -0.1,
+    })
+    data.append({
+        "group_id": 0, "statement_id": 2,
+        "na": 1, "nd": 8, "ns": 10,
+        "pa": 0.15, "pd": 0.75, "pat": -1.5, "pdt": 3.0,
+        "ra": 0.3, "rd": 1.8, "rat": -2.0, "rdt": 4.0,
+    })
+    # Group 1: similar but different
+    data.append({
+        "group_id": 1, "statement_id": 0,
+        "na": 3, "nd": 6, "ns": 10,
+        "pa": 0.35, "pd": 0.65, "pat": -0.5, "pdt": 1.5,
+        "ra": 0.7, "rd": 1.3, "rat": -1.0, "rdt": 2.0,
+    })
+    data.append({
+        "group_id": 1, "statement_id": 1,
+        "na": 6, "nd": 2, "ns": 10,
+        "pa": 0.65, "pd": 0.25, "pat": 1.5, "pdt": -0.5,
+        "ra": 1.3, "rd": 0.7, "rat": 2.0, "rdt": -1.0,
+    })
+    data.append({
+        "group_id": 1, "statement_id": 2,
+        "na": 4, "nd": 4, "ns": 10,
+        "pa": 0.45, "pd": 0.45, "pat": 0.0, "pdt": 0.0,
+        "ra": 1.0, "rd": 1.0, "rat": 0.0, "rdt": 0.0,
+    })
+
+    df = pd.DataFrame(data).set_index(["group_id", "statement_id"])
+    return df
+
+
+def test_rank_representative_statements_all_present():
+    df = _make_grouped_stats_df()
+    result = rank_representative_statements(df)
+    # 2 groups, 3 statements each
+    assert set(result.keys()) == {0, 1}
+    for gid in [0, 1]:
+        statement_ids = {s.statement_id for s in result[gid]}
+        assert statement_ids == {0, 1, 2}
+
+
+def test_rank_representative_statements_ranking_order():
+    df = _make_grouped_stats_df()
+    result = rank_representative_statements(df)
+    for gid in result:
+        statements = result[gid]
+        # Should be sorted by effect_size descending
+        effect_sizes = [s.effect_size for s in statements]
+        assert effect_sizes == sorted(effect_sizes, reverse=True)
+        # Rank 1 should have highest effect size
+        assert statements[0].rank == 1
+
+
+def test_rank_representative_statements_direction_selection():
+    df = _make_grouped_stats_df()
+    result = rank_representative_statements(df)
+    # Group 0, statement 0: strong agree (rat=4.0, pat=3.0 vs rdt=-2.0, pdt=-1.5)
+    stmt_0_g0 = [s for s in result[0] if s.statement_id == 0][0]
+    assert stmt_0_g0.repful_for == "agree"
+    # Group 0, statement 2: strong disagree (rdt=4.0, pdt=3.0 vs rat=-2.0, pat=-1.5)
+    stmt_2_g0 = [s for s in result[0] if s.statement_id == 2][0]
+    assert stmt_2_g0.repful_for == "disagree"
+
+
+def test_rank_representative_statements_effect_size():
+    df = _make_grouped_stats_df()
+    result = rank_representative_statements(df)
+    # Group 0, statement 0: agree direction, effect_size = ra * pa = 1.8 * 0.75
+    stmt_0_g0 = [s for s in result[0] if s.statement_id == 0][0]
+    assert stmt_0_g0.effect_size == pytest.approx(1.8 * 0.75)
+    # Group 0, statement 2: disagree direction, effect_size = rd * pd = 1.8 * 0.75
+    stmt_2_g0 = [s for s in result[0] if s.statement_id == 2][0]
+    assert stmt_2_g0.effect_size == pytest.approx(1.8 * 0.75)
+
+
+def test_rank_representative_statements_mod_out():
+    df = _make_grouped_stats_df()
+    result = rank_representative_statements(df, mod_out_statement_ids=[1])
+    for gid in result:
+        statement_ids = {s.statement_id for s in result[gid]}
+        assert 1 not in statement_ids
+        assert len(statement_ids) == 2
+
+
+def test_rank_representative_statements_zero_vote_filter():
+    """Zero-vote statements should not inflate BH hypothesis count."""
+    df = _make_grouped_stats_df()
+    # Add a zero-vote statement (na=0, nd=0) to each group
+    zero_vote_data = [
+        {
+            "group_id": 0, "statement_id": 99,
+            "na": 0, "nd": 0, "ns": 10,
+            "pa": 0.50, "pd": 0.50, "pat": 0.0, "pdt": 0.0,
+            "ra": 1.0, "rd": 1.0, "rat": 0.0, "rdt": 0.0,
+        },
+        {
+            "group_id": 1, "statement_id": 99,
+            "na": 0, "nd": 0, "ns": 10,
+            "pa": 0.50, "pd": 0.50, "pat": 0.0, "pdt": 0.0,
+            "ra": 1.0, "rd": 1.0, "rat": 0.0, "rdt": 0.0,
+        },
+    ]
+    df_with_zero = pd.concat([
+        df, pd.DataFrame(zero_vote_data).set_index(["group_id", "statement_id"])
+    ])
+
+    result_with = rank_representative_statements(df_with_zero)
+    result_without = rank_representative_statements(df)
+
+    for gid in result_with:
+        # Zero-vote statement should be present but never selected
+        zero_stmt = [s for s in result_with[gid] if s.statement_id == 99][0]
+        assert zero_stmt.selected is False
+        assert zero_stmt.adjusted_p_value == 1.0
+
+        # Selection of other statements should be identical (zero-vote doesn't inflate m)
+        sel_with = {s.statement_id for s in result_with[gid] if s.selected and s.statement_id != 99}
+        sel_without = {s.statement_id for s in result_without[gid] if s.selected}
+        assert sel_with == sel_without
+
+
+# --- rank_consensus_statements ---
+
+
+def _make_consensus_vote_matrix():
+    """Create a synthetic vote matrix for consensus testing."""
+    # 10 voters, 4 statements
+    return pd.DataFrame(
+        {
+            0: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],      # strong agree
+            1: [-1, -1, -1, -1, -1, -1, -1, -1, 1, 1],  # strong disagree
+            2: [1, 1, 1, -1, -1, -1, 0, 0, 0, 0],    # mixed
+            3: [1, 1, 1, 1, 1, 1, -1, -1, -1, -1],   # moderate agree
+        },
+        index=list(range(10)),
+    )
+
+
+def test_rank_consensus_statements_all_present():
+    vm = _make_consensus_vote_matrix()
+    result = rank_consensus_statements(vm)
+    agree_ids = {s.statement_id for s in result.agree}
+    disagree_ids = {s.statement_id for s in result.disagree}
+    # All 4 statements should appear in both directions
+    assert agree_ids == {0, 1, 2, 3}
+    assert disagree_ids == {0, 1, 2, 3}
+
+
+def test_rank_consensus_statements_ranking():
+    vm = _make_consensus_vote_matrix()
+    result = rank_consensus_statements(vm)
+    # Agree: ranked by pa descending
+    agree_pa = [s.pa for s in result.agree]
+    assert agree_pa == sorted(agree_pa, reverse=True)
+    # Disagree: ranked by pd descending
+    disagree_pd = [s.pd for s in result.disagree]
+    assert disagree_pd == sorted(disagree_pd, reverse=True)
+
+
+def test_rank_consensus_statements_effect_size_matches_probability():
+    vm = _make_consensus_vote_matrix()
+    result = rank_consensus_statements(vm)
+    for s in result.agree:
+        assert s.effect_size == pytest.approx(s.pa)
+    for s in result.disagree:
+        assert s.effect_size == pytest.approx(s.pd)
+
+
+# --- effective agreement GAC ---
+
+
+def test_effective_agreement_penalizes_divided_groups():
+    """A group split between agree/disagree should lower GAC vs unanimous."""
+    # 2 groups of 5 participants, 1 statement.
+    # Group 0: all agree. Group 1: split 3 agree / 2 disagree.
+    vote_matrix_divided = pd.DataFrame(
+        {0: [1, 1, 1, 1, 1, 1, 1, 1, -1, -1]},
+        index=list(range(10)),
+    )
+    cluster_labels = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+
+    vote_matrix_unanimous = pd.DataFrame(
+        {0: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
+        index=list(range(10)),
+    )
+
+    grouped_divided, _ = calculate_comment_statistics_dataframes(
+        vote_matrix=vote_matrix_divided, cluster_labels=cluster_labels,
+    )
+    grouped_unanimous, _ = calculate_comment_statistics_dataframes(
+        vote_matrix=vote_matrix_unanimous, cluster_labels=cluster_labels,
+    )
+
+    gac_divided = compute_effective_agreement_gac(grouped_divided, [0], n_groups=2)
+    gac_unanimous = compute_effective_agreement_gac(grouped_unanimous, [0], n_groups=2)
+
+    # Divided group should lower the score
+    assert gac_divided["agree"][0] < gac_unanimous["agree"][0]
+    # A group split 3/2 should produce a score below 0.5
+    assert gac_divided["agree"][0] < 0.5
+    # Unanimous agreement should be well above 0.5
+    assert gac_unanimous["agree"][0] > 0.5
+
+
+def test_effective_agreement_gac_bounded():
+    """All GAC scores should be in [0, 1] and <= raw pa baseline."""
+    vote_matrix = pd.DataFrame(
+        {
+            0: [1, 1, 1, -1, -1, 1],
+            1: [-1, -1, 1, 1, 1, -1],
+            2: [1, 1, 1, 1, 1, 1],
+        },
+        index=list(range(6)),
+    )
+    cluster_labels = [0, 0, 0, 1, 1, 1]
+
+    grouped_stats_df, _ = calculate_comment_statistics_dataframes(
+        vote_matrix=vote_matrix, cluster_labels=cluster_labels,
+    )
+    n_groups = 2
+    statement_ids = vote_matrix.columns.tolist()
+
+    gac = compute_effective_agreement_gac(grouped_stats_df, statement_ids, n_groups)
+
+    for sid in statement_ids:
+        ea = gac["agree"][sid]
+        ed = gac["disagree"][sid]
+        assert 0 <= ea <= 1, f"agree GAC {ea} out of [0,1] for statement {sid}"
+        assert 0 <= ed <= 1, f"disagree GAC {ed} out of [0,1] for statement {sid}"
+
+        # Effective agreement should be <= raw pa geometric mean
+        pa_product = 1.0
+        for gid in range(n_groups):
+            pa = grouped_stats_df.loc[(gid, sid), "pa"]
+            pa_product *= pa
+        raw_baseline = pa_product ** (1.0 / n_groups)
+        assert ea <= raw_baseline + 1e-9, (
+            f"Statement {sid}: effective agreement {ea} > raw baseline {raw_baseline}"
+        )

--- a/tests/utils/test_stats.py
+++ b/tests/utils/test_stats.py
@@ -311,12 +311,6 @@ def test_priority_metric_array():
 
 @pytest.mark.parametrize("polis_convo_data", ["small-no-meta", "small-with-meta", "medium-no-meta", "medium-with-meta"], indirect=True)
 def test_group_aware_consensus_real_data(polis_convo_data):
-    """
-    Verify group-aware consensus on real Polis data.
-
-    Tests both the Polis-compatible baseline (geometric mean of raw p_agree)
-    and our effective agreement divergence (p_agree * (1 - p_disagree)).
-    """
     fixture = polis_convo_data
     loader = Loader(filepaths=[
         f'{fixture.data_dir}/votes.json',
@@ -339,34 +333,20 @@ def test_group_aware_consensus_real_data(polis_convo_data):
     all_clustered_participant_ids, cluster_labels = polismath.extract_data_from_polismath(fixture.math_data)
     vote_matrix = vote_matrix.loc[all_clustered_participant_ids, :]
 
-    # Generate stats for all groups and all statements.
-    # This returns both per-group probabilities (P_v_g_c) and
-    # the final group-aware consensus (C_v_c) which uses effective agreement.
-    N_g_c, N_v_g_c, P_v_g_c, _, P_v_g_c_test, _, C_v_c = stats.calculate_comment_statistics(
+    # Generate stats all groups and all statements.
+    _, gac_df = stats.calculate_comment_statistics_dataframes(
         vote_matrix=vote_matrix,
         cluster_labels=cluster_labels,
     )
 
-    n_groups = len(set(cluster_labels))
-
-    # 1) Verify Polis baseline: geometric mean of raw p_agree still matches fixtures
-    polis_baseline_agree = P_v_g_c[stats.votes.A, :, :].prod(axis=0) ** (1.0 / n_groups)
-    calculated_baseline = {
-        str(sid): float(polis_baseline_agree[i])
-        for i, sid in enumerate(vote_matrix.columns)
+    calculated_gac = {
+        str(pid): float(row.iloc[0])
+        for pid, row in gac_df.iterrows()
     }
-    expected_polis_gac = helpers.polis_gac_to_geometric_mean(n_groups, fixture.math_data["group-aware-consensus"])
-    assert calculated_baseline == pytest.approx(expected_polis_gac)
 
-    # 2) Verify effective agreement scores are in [0, 1] and <= Polis baseline
-    for i, sid in enumerate(vote_matrix.columns):
-        effective_score = float(C_v_c[stats.votes.A, i])
-        baseline_score = float(polis_baseline_agree[i])
-        assert 0 <= effective_score <= 1, f"Statement {sid}: score {effective_score} out of [0, 1]"
-        assert effective_score <= baseline_score + 1e-9, (
-            f"Statement {sid}: effective agreement {effective_score} should be "
-            f"<= Polis baseline {baseline_score}"
-        )
+    n_groups = len(set(cluster_labels))
+    expected_gac = helpers.polis_gac_to_geometric_mean(n_groups, fixture.math_data["group-aware-consensus"])
+    assert calculated_gac == pytest.approx(expected_gac)
 
 
 def test_group_aware_consensus_uses_geometric_mean():
@@ -397,57 +377,14 @@ def test_group_aware_consensus_uses_geometric_mean():
     agree_score_2_groups = C_2[0, 0]  # votes.A = 0
     agree_score_3_groups = C_3[0, 0]
 
-    # With geometric mean, both should be reasonably close (same underlying consensus).
-    # Without it (raw product), 3 groups would give much lower scores.
-    # The effective agreement formula (p_agree * (1 - p_disagree)) amplifies
-    # the Laplace smoothing gap between group sizes, so the tolerance is wider
-    # than with raw p_agree alone.
-    assert agree_score_2_groups == pytest.approx(agree_score_3_groups, abs=0.1)
+    # With geometric mean, both should be close (same underlying consensus).
+    # Without it (raw product), 3 groups would give 0.512 vs 0.640 — much wider gap.
+    # Small difference remains due to Laplace smoothing on smaller groups.
+    assert agree_score_2_groups == pytest.approx(agree_score_3_groups, abs=0.06)
 
-    # Both should be above 0.5 (all participants agree)
+    # Both should be well above 0.5 (all participants agree)
     assert agree_score_2_groups > 0.5
     assert agree_score_3_groups > 0.5
-
-
-def test_group_aware_consensus_penalizes_divided_groups():
-    """
-    Verify that a group split roughly evenly between agree and disagree
-    drags down the consensus score compared to unanimous agreement.
-
-    This is the core behavior of the effective agreement divergence from Polis.
-    """
-    # 2 groups of 5 participants, 1 statement.
-    # Group 0: all agree. Group 1: split 3 agree / 2 disagree.
-    vote_matrix_divided = pd.DataFrame(
-        {0: [1, 1, 1, 1, 1, 1, 1, 1, -1, -1]},
-        index=list(range(10)),
-    )
-    cluster_labels = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
-
-    # Unanimous: both groups fully agree
-    vote_matrix_unanimous = pd.DataFrame(
-        {0: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
-        index=list(range(10)),
-    )
-
-    *_, C_divided = stats.calculate_comment_statistics(
-        vote_matrix=vote_matrix_divided,
-        cluster_labels=cluster_labels,
-    )
-    *_, C_unanimous = stats.calculate_comment_statistics(
-        vote_matrix=vote_matrix_unanimous,
-        cluster_labels=cluster_labels,
-    )
-
-    divided_score = C_divided[stats.votes.A, 0]
-    unanimous_score = C_unanimous[stats.votes.A, 0]
-
-    # Divided group should significantly lower the consensus score
-    assert divided_score < unanimous_score
-    # A group split 3/2 should produce a score below 0.5 (not genuine consensus)
-    assert divided_score < 0.5
-    # Unanimous agreement should be well above 0.5
-    assert unanimous_score > 0.5
 
 
 def test_format_comment_stats_repful_agree():

--- a/tests/utils/test_stats.py
+++ b/tests/utils/test_stats.py
@@ -311,6 +311,12 @@ def test_priority_metric_array():
 
 @pytest.mark.parametrize("polis_convo_data", ["small-no-meta", "small-with-meta", "medium-no-meta", "medium-with-meta"], indirect=True)
 def test_group_aware_consensus_real_data(polis_convo_data):
+    """
+    Verify group-aware consensus on real Polis data.
+
+    Tests both the Polis-compatible baseline (geometric mean of raw p_agree)
+    and our effective agreement divergence (p_agree * (1 - p_disagree)).
+    """
     fixture = polis_convo_data
     loader = Loader(filepaths=[
         f'{fixture.data_dir}/votes.json',
@@ -333,20 +339,34 @@ def test_group_aware_consensus_real_data(polis_convo_data):
     all_clustered_participant_ids, cluster_labels = polismath.extract_data_from_polismath(fixture.math_data)
     vote_matrix = vote_matrix.loc[all_clustered_participant_ids, :]
 
-    # Generate stats all groups and all statements.
-    _, gac_df = stats.calculate_comment_statistics_dataframes(
+    # Generate stats for all groups and all statements.
+    # This returns both per-group probabilities (P_v_g_c) and
+    # the final group-aware consensus (C_v_c) which uses effective agreement.
+    N_g_c, N_v_g_c, P_v_g_c, _, P_v_g_c_test, _, C_v_c = stats.calculate_comment_statistics(
         vote_matrix=vote_matrix,
         cluster_labels=cluster_labels,
     )
 
-    calculated_gac = {
-        str(pid): float(row.iloc[0])
-        for pid, row in gac_df.iterrows()
-    }
-
     n_groups = len(set(cluster_labels))
-    expected_gac = helpers.polis_gac_to_geometric_mean(n_groups, fixture.math_data["group-aware-consensus"])
-    assert calculated_gac == pytest.approx(expected_gac)
+
+    # 1) Verify Polis baseline: geometric mean of raw p_agree still matches fixtures
+    polis_baseline_agree = P_v_g_c[stats.votes.A, :, :].prod(axis=0) ** (1.0 / n_groups)
+    calculated_baseline = {
+        str(sid): float(polis_baseline_agree[i])
+        for i, sid in enumerate(vote_matrix.columns)
+    }
+    expected_polis_gac = helpers.polis_gac_to_geometric_mean(n_groups, fixture.math_data["group-aware-consensus"])
+    assert calculated_baseline == pytest.approx(expected_polis_gac)
+
+    # 2) Verify effective agreement scores are in [0, 1] and <= Polis baseline
+    for i, sid in enumerate(vote_matrix.columns):
+        effective_score = float(C_v_c[stats.votes.A, i])
+        baseline_score = float(polis_baseline_agree[i])
+        assert 0 <= effective_score <= 1, f"Statement {sid}: score {effective_score} out of [0, 1]"
+        assert effective_score <= baseline_score + 1e-9, (
+            f"Statement {sid}: effective agreement {effective_score} should be "
+            f"<= Polis baseline {baseline_score}"
+        )
 
 
 def test_group_aware_consensus_uses_geometric_mean():
@@ -377,14 +397,57 @@ def test_group_aware_consensus_uses_geometric_mean():
     agree_score_2_groups = C_2[0, 0]  # votes.A = 0
     agree_score_3_groups = C_3[0, 0]
 
-    # With geometric mean, both should be close (same underlying consensus).
-    # Without it (raw product), 3 groups would give 0.512 vs 0.640 — much wider gap.
-    # Small difference remains due to Laplace smoothing on smaller groups.
-    assert agree_score_2_groups == pytest.approx(agree_score_3_groups, abs=0.06)
+    # With geometric mean, both should be reasonably close (same underlying consensus).
+    # Without it (raw product), 3 groups would give much lower scores.
+    # The effective agreement formula (p_agree * (1 - p_disagree)) amplifies
+    # the Laplace smoothing gap between group sizes, so the tolerance is wider
+    # than with raw p_agree alone.
+    assert agree_score_2_groups == pytest.approx(agree_score_3_groups, abs=0.1)
 
-    # Both should be well above 0.5 (all participants agree)
+    # Both should be above 0.5 (all participants agree)
     assert agree_score_2_groups > 0.5
     assert agree_score_3_groups > 0.5
+
+
+def test_group_aware_consensus_penalizes_divided_groups():
+    """
+    Verify that a group split roughly evenly between agree and disagree
+    drags down the consensus score compared to unanimous agreement.
+
+    This is the core behavior of the effective agreement divergence from Polis.
+    """
+    # 2 groups of 5 participants, 1 statement.
+    # Group 0: all agree. Group 1: split 3 agree / 2 disagree.
+    vote_matrix_divided = pd.DataFrame(
+        {0: [1, 1, 1, 1, 1, 1, 1, 1, -1, -1]},
+        index=list(range(10)),
+    )
+    cluster_labels = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+
+    # Unanimous: both groups fully agree
+    vote_matrix_unanimous = pd.DataFrame(
+        {0: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
+        index=list(range(10)),
+    )
+
+    *_, C_divided = stats.calculate_comment_statistics(
+        vote_matrix=vote_matrix_divided,
+        cluster_labels=cluster_labels,
+    )
+    *_, C_unanimous = stats.calculate_comment_statistics(
+        vote_matrix=vote_matrix_unanimous,
+        cluster_labels=cluster_labels,
+    )
+
+    divided_score = C_divided[stats.votes.A, 0]
+    unanimous_score = C_unanimous[stats.votes.A, 0]
+
+    # Divided group should significantly lower the consensus score
+    assert divided_score < unanimous_score
+    # A group split 3/2 should produce a score below 0.5 (not genuine consensus)
+    assert divided_score < 0.5
+    # Unanimous agreement should be well above 0.5
+    assert unanimous_score > 0.5
 
 
 def test_format_comment_stats_repful_agree():


### PR DESCRIPTION
> **Updated 2026-03-12:** This PR expanded from Polis repness bug fixes into the full Agora pipeline implementation. See [this comment](https://github.com/polis-community/red-dwarf/pull/99#issuecomment-4047841847) for the full technical rationale.

## Summary

Re-adds the Agora implementation as the recommended default pipeline, with principled statistical methods replacing Polis's ad-hoc heuristics. Also fixes several bugs in the Polis repness selection.

### Polis bug fixes (in `select_representative_statements`)

- Fix repful_for calculation to use correct test statistics (pat/pdt)
- Remove buggy best-agree/best-of-agrees heuristic (was using disagree data for agree statements)
- Fix format_comment_stats to output correct direction fields
- Filter out zero-vote statements from significance testing

### Agora implementation (new)

- `rank_representative_statements()` — ranks ALL statements per group by effect size, with BH FDR selection using Simes' p-value combination
- `rank_consensus_statements()` — ranks ALL statements by pa/pd with BH selection
- `compute_effective_agreement_gac()` — `prod(pa*(1-pd))^(1/n)` penalizes divided groups
- `apply_bh_with_vote_filter()` — shared BH helper excluding zero-vote statements
- `AgoraClusteringResult` with ranked_repness, ranked_consensus, effective GAC

### Documentation

- README: Agora as recommended default, Polis vs Agora comparison table, roadmap
- API reference: Agora functions and types, fix base section bug
- CHANGELOG: all additions documented
- `agora-demo.ipynb` notebook as recommended quickstart
- Cram snapshot tests with Polis vs Agora selection comparison

Closes #73
Supersedes #105

<details>
<summary>Original PR description (August 2025)</summary>

Fixed:
- representative opinion used to be formatted wrongly (using repful_for=disagree data instead of agree for example), especially when it comes to the "best-agree"
- the way to select representative opinions and then select them for formatting was different, so it was leading to errors.
- we're now sorting representative opinions by repness-test before using pick-max so we're sure we have the best ones

TODO:
- best-agree support was temporarily removed for now, as the implementation was flawed
- instead of the previous implementation we should select the best "agree" of the existing selected representative opinions after pick_max filter, if any, and then update the column to add "best-agree: true". There might be not best-agree sometimes when tehre is no "agree" representative opinions, and it's expected according to my experience I think sometimes there is no best-agree at all (it also makes sense in general I think, but I may be wrong)
- add unit tests!

</details>