### PR TITLE
bugfix: Ensure we don't crash when a non-existent keep_participant_ids item is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - bugfix: `clusterer_kwargs` and `reducer_kwargs` were not being pass through `run_pipeline()`.
 - bugfix: Ensure `run_pipeline()` passes `random_state` to reducer.
 - bugfix: Fix overly constrained versions from [#80](https://github.com/polis-community/red-dwarf/issues/80).
+- bugfix: Ensure we don't crash when a participant ID in `keep_participant_ids` doesn't exist in vote matrix.
 
 ### Chores
 

--- a/reddwarf/implementations/base.py
+++ b/reddwarf/implementations/base.py
@@ -118,10 +118,11 @@ def run_pipeline(
         raw_vote_matrix, vote_threshold=min_user_vote_threshold
     )
     if keep_participant_ids:
-        # TODO: Make this an intersection, in case there are members of
-        # keep_participant_ids list that aren't represented in vote_matrix.
+        # Ensure we're not trying to keep any participant IDs that don't exist in matrix.
+        # TODO: Does this break any assumptions?
+        keep_participant_ids_existing = participants_df.index.intersection(keep_participant_ids).to_list()
         participant_ids_to_cluster = sorted(
-            list(set(participant_ids_to_cluster + keep_participant_ids))
+            list(set(participant_ids_to_cluster + keep_participant_ids_existing))
         )
 
     clusterer_model = run_clusterer(

--- a/tests/implementations/test_base.py
+++ b/tests/implementations/test_base.py
@@ -7,6 +7,7 @@ from tests.fixtures import polis_convo_data
 
 ## Determinism via random_seed for run_pipeline()
 
+
 @pytest.mark.parametrize("reducer", ["pca", "pacmap", "localmap"])
 @pytest.mark.parametrize("polis_convo_data", ["small-no-meta"], indirect=True)
 def test_run_pipeline_deterministic_with_random_state(reducer, polis_convo_data):
@@ -20,28 +21,24 @@ def test_run_pipeline_deterministic_with_random_state(reducer, polis_convo_data)
     random_state = 42
 
     # Run pipeline twice with same random_state
-    result_1 = run_pipeline(
-        votes=votes,
-        reducer=reducer,
-        random_state=random_state
-    )
+    result_1 = run_pipeline(votes=votes, reducer=reducer, random_state=random_state)
 
-    result_2 = run_pipeline(
-        votes=votes,
-        reducer=reducer,
-        random_state=random_state
-    )
+    result_2 = run_pipeline(votes=votes, reducer=reducer, random_state=random_state)
 
     # Results should be identical when using same random_state
     # Convert participant_projections dict to arrays for comparison
     participant_ids = sorted(result_1.participant_projections.keys())
-    projections_1 = np.array([result_1.participant_projections[pid] for pid in participant_ids])
-    projections_2 = np.array([result_2.participant_projections[pid] for pid in participant_ids])
+    projections_1 = np.array(
+        [result_1.participant_projections[pid] for pid in participant_ids]
+    )
+    projections_2 = np.array(
+        [result_2.participant_projections[pid] for pid in participant_ids]
+    )
 
     np.testing.assert_array_equal(
         projections_1,
         projections_2,
-        err_msg=f"{reducer} with random_state should produce identical participant projections"
+        err_msg=f"{reducer} with random_state should produce identical participant projections",
     )
 
 
@@ -56,37 +53,35 @@ def test_run_pipeline_not_deterministic_without_random_state(reducer, polis_conv
     votes = loader.votes_data
 
     # Run pipeline twice without random_state (should be non-deterministic)
-    result_1 = run_pipeline(
-        votes=votes,
-        reducer=reducer,
-        random_state=None
-    )
+    result_1 = run_pipeline(votes=votes, reducer=reducer, random_state=None)
 
-    result_2 = run_pipeline(
-        votes=votes,
-        reducer=reducer,
-        random_state=None
-    )
+    result_2 = run_pipeline(votes=votes, reducer=reducer, random_state=None)
 
     # Results should be different when not using random_state
     # Convert participant_projections dict to arrays for comparison
     participant_ids = sorted(result_1.participant_projections.keys())
-    projections_1 = np.array([result_1.participant_projections[pid] for pid in participant_ids])
-    projections_2 = np.array([result_2.participant_projections[pid] for pid in participant_ids])
+    projections_1 = np.array(
+        [result_1.participant_projections[pid] for pid in participant_ids]
+    )
+    projections_2 = np.array(
+        [result_2.participant_projections[pid] for pid in participant_ids]
+    )
 
     # We use assert_raises to expect that arrays are NOT equal
     with pytest.raises(AssertionError):
         np.testing.assert_array_equal(
             projections_1,
             projections_2,
-            err_msg=f"{reducer} without random_state should produce different participant projections"
+            err_msg=f"{reducer} without random_state should produce different participant projections",
         )
 
 
 # Note: PCA is always deterministic regardless of random_state
 @pytest.mark.parametrize("reducer", ["pca"])
 @pytest.mark.parametrize("polis_convo_data", ["small-no-meta"], indirect=True)
-def test_run_pipeline_pca_still_deterministic_without_random_state(reducer, polis_convo_data):
+def test_run_pipeline_pca_still_deterministic_without_random_state(
+    reducer, polis_convo_data
+):
     """Test that not setting random_state for PCA is still deterministic across runs."""
     fixture = polis_convo_data
 
@@ -95,26 +90,22 @@ def test_run_pipeline_pca_still_deterministic_without_random_state(reducer, poli
     votes = loader.votes_data
 
     # Run pipeline twice without random_state (PCA should still be deterministic)
-    result_1 = run_pipeline(
-        votes=votes,
-        reducer=reducer,
-        random_state=None
-    )
+    result_1 = run_pipeline(votes=votes, reducer=reducer, random_state=None)
 
-    result_2 = run_pipeline(
-        votes=votes,
-        reducer=reducer,
-        random_state=None
-    )
+    result_2 = run_pipeline(votes=votes, reducer=reducer, random_state=None)
 
     # Results should be identical even without random_state for PCA
     # Convert participant_projections dict to arrays for comparison
     participant_ids = sorted(result_1.participant_projections.keys())
-    projections_1 = np.array([result_1.participant_projections[pid] for pid in participant_ids])
-    projections_2 = np.array([result_2.participant_projections[pid] for pid in participant_ids])
+    projections_1 = np.array(
+        [result_1.participant_projections[pid] for pid in participant_ids]
+    )
+    projections_2 = np.array(
+        [result_2.participant_projections[pid] for pid in participant_ids]
+    )
 
     np.testing.assert_array_equal(
         projections_1,
         projections_2,
-        err_msg=f"{reducer} should produce identical participant projections even without random_state"
+        err_msg=f"{reducer} should produce identical participant projections even without random_state",
     )


### PR DESCRIPTION
In some old polis conversation, math data contains a participant ID (in `in-conv` key of polis math object) that has no votes in the built vote matrix. (We use `in-conv` to gather participant IDs that polis thinks should be in the conversation based on some of its bespoke "keep" rules that we don't implement.)

Currently, run_pipeline() crashes when it's passed a participant_id that doesn't exist in the vote matrix, we should have it more gracefully.

### To Dos
- [x] simple fix
- [x] add a test that fails without this
- [ ] consider raising some sort of warning, to make known that we were passed weird data (tends to be older polis conversations -- perhaps worth figuring out why this is happening)