### PR TITLE
Fixed sanity check test failures due to new fields in API responses

### DIFF
--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -25,7 +25,7 @@ def test_load_data_from_api_conversation():
         'help_color', 'is_data_open', 'is_curated', 'dataset_explanation',
         'write_hint_type', 'subscribe_type', 'org_id', 'need_suzinvite',
         'use_xid_whitelist', 'prioritize_seed', 'importance_enabled',
-        'site_id', 'translations',
+        'site_id', 'translations', 'treevite_enabled',
         'ownername', 'is_mod', 'is_owner', 'conversation_id',
     ]
     assert sorted(loader.conversation_data) == sorted(expected_keys)
@@ -147,6 +147,7 @@ def test_load_data_from_api_report():
     expected_keys = [
         'report_id',
         'created',
+        'mod_level',
         'modified',
         'label_x_neg',
         'label_y_neg',


### PR DESCRIPTION
There are some sanity checks in here so that we're not caught off-guard if Polis starts returning new fields or changing features. These were added.