### PR TITLE
fix(stats): use geometric mean for group-aware consensus + fix tests

### DIFF
--- a/reddwarf/utils/stats.py
+++ b/reddwarf/utils/stats.py
@@ -294,10 +294,14 @@ def calculate_comment_statistics(
         )  # rdt
 
     # Calculate group-aware consensus
-    # For each statement, multiply probabilities across groups (aka the first axis=0)
+    # Geometric mean: normalize for group count so that similar levels of
+    # cross-group consensus produce similar scores regardless of whether
+    # the conversation has 2 or 6 opinion groups. This helps when applying
+    # a selection algorithm with a fixed threshold (e.g. 0.5).
     # Reference: https://github.com/compdemocracy/polis/blob/edge/math/src/polismath/math/conversation.clj#L615-L636
-    C_v_c[votes.A, :] = P_v_g_c[votes.A, :, :].prod(axis=0)
-    C_v_c[votes.D, :] = P_v_g_c[votes.D, :, :].prod(axis=0)
+    n_groups = P_v_g_c.shape[1]
+    C_v_c[votes.A, :] = P_v_g_c[votes.A, :, :].prod(axis=0) ** (1.0 / n_groups)
+    C_v_c[votes.D, :] = P_v_g_c[votes.D, :, :].prod(axis=0) ** (1.0 / n_groups)
 
     return (
         N_g_c,  # ns

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -223,6 +223,19 @@ def simulate_api_response(data):
     """
     return json.loads(json.dumps(dict(data)))
 
+def polis_gac_to_geometric_mean(n_groups, polis_gac):
+    """
+    Transform Polis raw-product group-aware-consensus values into geometric mean.
+
+    Polis fixture data uses raw product (prod of per-group probabilities).
+    Reddwarf uses geometric mean (product^(1/n_groups)) to normalize for group count.
+    """
+    return {
+        k: v ** (1.0 / n_groups)
+        for k, v in polis_gac.items()
+    }
+
+
 class ReportType(Enum):
     SUMMARY = "summary"
     VOTES = "votes"

--- a/tests/implementations/test_polis.py
+++ b/tests/implementations/test_polis.py
@@ -64,10 +64,11 @@ def test_run_clustering_real_data_small(polis_convo_data):
     )
 
     # Check group-aware-consensus calculations.
+    n_groups = len(math_data["group-clusters"])
     calculated = helpers.simulate_api_response(
         result.statements_df["group-aware-consensus"].items()
     )
-    expected = math_data["group-aware-consensus"]
+    expected = helpers.polis_gac_to_geometric_mean(n_groups, math_data["group-aware-consensus"])
     assert_dict_equal(calculated, expected)
 
     # Check PCA components and means

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -27,6 +27,7 @@ def test_load_data_from_api_conversation():
         'use_xid_whitelist', 'prioritize_seed', 'importance_enabled',
         'site_id', 'translations', 'treevite_enabled',
         'ownername', 'is_mod', 'is_owner', 'conversation_id',
+        'topics_enabled',
     ]
     assert sorted(loader.conversation_data) == sorted(expected_keys)
 

--- a/tests/utils/test_comment_statistics.py
+++ b/tests/utils/test_comment_statistics.py
@@ -116,8 +116,11 @@ def test_calculate_comment_statistics_dataframes_gac_df_real_data(polis_convo_da
     fixture = polis_convo_data
     _, gac_df = setup_test(fixture)
 
+    _, cluster_labels = polismath.extract_data_from_polismath(fixture.math_data)
+    n_groups = len(set(cluster_labels))
+
     calculated = helpers.simulate_api_response(gac_df["group-aware-consensus"].items())
-    expected = fixture.math_data["group-aware-consensus"]
+    expected = helpers.polis_gac_to_geometric_mean(n_groups, fixture.math_data["group-aware-consensus"])
     assert_dict_equal(calculated, expected)
 
 

--- a/tests/utils/test_stats.py
+++ b/tests/utils/test_stats.py
@@ -6,6 +6,7 @@ from reddwarf.utils import stats
 
 from reddwarf.utils import stats, polismath, matrix
 from reddwarf.data_loader import Loader
+from tests import helpers
 
 def test_importance_metric_no_votes():
     expected_importance = [ 1/4,   2/4,   1,     2,      4   ]
@@ -343,7 +344,48 @@ def test_group_aware_consensus_real_data(polis_convo_data):
         for pid, row in gac_df.iterrows()
     }
 
-    assert calculated_gac == pytest.approx(fixture.math_data["group-aware-consensus"])
+    n_groups = len(set(cluster_labels))
+    expected_gac = helpers.polis_gac_to_geometric_mean(n_groups, fixture.math_data["group-aware-consensus"])
+    assert calculated_gac == pytest.approx(expected_gac)
+
+
+def test_group_aware_consensus_uses_geometric_mean():
+    """
+    Verify that group-aware consensus uses geometric mean (product^(1/n_groups))
+    so that scores are comparable regardless of the number of groups.
+    """
+    # Build a vote matrix: 6 participants, 2 groups, 1 statement.
+    # All participants agree on the statement.
+    vote_matrix = pd.DataFrame(
+        {0: [1, 1, 1, 1, 1, 1]},
+        index=[0, 1, 2, 3, 4, 5],
+    )
+    # 2 groups of 3 participants each
+    cluster_labels_2 = [0, 0, 0, 1, 1, 1]
+    # 3 groups of 2 participants each
+    cluster_labels_3 = [0, 0, 1, 1, 2, 2]
+
+    *_, C_2 = stats.calculate_comment_statistics(
+        vote_matrix=vote_matrix,
+        cluster_labels=cluster_labels_2,
+    )
+    *_, C_3 = stats.calculate_comment_statistics(
+        vote_matrix=vote_matrix,
+        cluster_labels=cluster_labels_3,
+    )
+
+    agree_score_2_groups = C_2[0, 0]  # votes.A = 0
+    agree_score_3_groups = C_3[0, 0]
+
+    # With geometric mean, both should be close (same underlying consensus).
+    # Without it (raw product), 3 groups would give 0.512 vs 0.640 — much wider gap.
+    # Small difference remains due to Laplace smoothing on smaller groups.
+    assert agree_score_2_groups == pytest.approx(agree_score_3_groups, abs=0.06)
+
+    # Both should be well above 0.5 (all participants agree)
+    assert agree_score_2_groups > 0.5
+    assert agree_score_3_groups > 0.5
+
 
 def test_format_comment_stats_repful_agree():
     statement = pd.Series({

--- a/tests/utils/test_string_id.py
+++ b/tests/utils/test_string_id.py
@@ -106,10 +106,11 @@ def test_run_pipeline_with_string_statement_ids(polis_convo_data):
         force_group_count=force_group_count,
     )
     
+    n_groups = len(math_data["group-clusters"])
     calculated = helpers.simulate_api_response(
         result.statements_df["group-aware-consensus"].items()
     )
-    expected = math_data["group-aware-consensus"]
+    expected = helpers.polis_gac_to_geometric_mean(n_groups, math_data["group-aware-consensus"])
     assert_dict_equal(calculated, expected)
 
     assert pytest.approx(result.reducer.components_[0]) == math_data["pca"]["comps"][0]


### PR DESCRIPTION
## Summary
- Replace raw product with geometric mean (`product^(1/n_groups)`) for group-aware consensus scores
- Fixes consensus scores being unreachable for conversations with 4-6 opinion groups (e.g. 93% cross-group agreement scored ~0.33 with 6 groups, below the 0.5 selection threshold)
- No-op when `n_groups=1` (e.g. `select_consensus_statements`)
- Fix pre-existing `topics_enabled` missing key in data loader test

## Test plan
- [x] All 8 existing group-aware consensus tests updated and passing
- [x] 2 string ID tests updated and passing
- [x] New unit test `test_group_aware_consensus_uses_geometric_mean` verifying scores are comparable across 2 vs 3 groups
- [x] `select_consensus_statements` unaffected (uses `cluster_labels=None` → single group → exponent 1/1)
- [x] Repness selection unaffected (does not use `C_v_c`)
- [x] `test_data_loader` fix: add `topics_enabled` to expected conversation keys (new Polis API field)