### PR TITLE
fix(kmeans): reject k values that produce singleton clusters

### DIFF
--- a/reddwarf/utils/clusterer/kmeans.py
+++ b/reddwarf/utils/clusterer/kmeans.py
@@ -90,6 +90,9 @@ def find_best_kmeans(
 
     def scoring_function(estimator, X):
         labels = estimator.fit_predict(X)
+        unique, counts = np.unique(labels, return_counts=True)
+        if counts.min() < 2:
+            return -1
         return silhouette_score(X, labels)
 
     search = GridSearchNonCV(

--- a/tests/utils/clusterer/test_kmeans.py
+++ b/tests/utils/clusterer/test_kmeans.py
@@ -1,8 +1,30 @@
 import pytest
+import numpy as np
 from reddwarf.utils.clusterer.kmeans import run_kmeans, find_best_kmeans
 from tests.fixtures import polis_convo_data
 from tests.helpers import transform_base_clusters_to_participant_coords
 import pandas as pd
+
+
+def test_find_best_kmeans_rejects_singleton_clusters():
+    """find_best_kmeans should never select a k that produces a singleton cluster."""
+    np.random.seed(42)
+    cluster1 = np.random.normal(loc=[0, 0], scale=0.3, size=(30, 2))
+    cluster2 = np.random.normal(loc=[5, 5], scale=0.3, size=(30, 2))
+    outlier = np.array([[10, 10]])
+    X = np.vstack([cluster1, cluster2, outlier])
+
+    best_k, _, best_kmeans = find_best_kmeans(
+        X_to_cluster=X,
+        k_bounds=[2, 5],
+        random_state=42,
+    )
+
+    if best_kmeans is not None:
+        unique, counts = np.unique(best_kmeans.labels_, return_counts=True)
+        assert counts.min() >= 2, (
+            f"k={best_k} produced singleton cluster(s): {dict(zip(unique, counts))}"
+        )
 
 @pytest.mark.parametrize("polis_convo_data", ["small"], indirect=True)
 def test_run_kmeans_real_data_reproducible(polis_convo_data):


### PR DESCRIPTION
## Problem

`find_best_kmeans` uses silhouette scores to select the optimal number of clusters (k). However, it can select a k value where one or more clusters contain only a single participant. A singleton cluster is statistically meaningless — you can't derive group-level insights from one person — and it degrades downstream calculations like representative statements and group-aware consensus.

Related issues:
- #2 — Ensure singleton clusters aren't possible with k-means clustering
- #97 — Prevent singleton clusters from being displayed

### Real-world example

In production with 58 clusterable participants, the algorithm selected k=2 producing groups of `[1, 57]` — effectively a single-group result. The silhouette score for this degenerate split was higher than alternatives with more balanced distributions.

### How upstream Polis handles this

Polis invalidates any k value that produces a singleton cluster during silhouette scoring:
https://github.com/compdemocracy/polis/blob/edge/math/src/polismath/math/clusters.clj#L350-L354

## Solution

Modify the `scoring_function` inside `find_best_kmeans` to return `-1` (worst possible silhouette score) for any k where the smallest cluster has fewer than 2 members. This prevents singleton-producing k values from being selected as optimal.

This is the same approach as Polis (Option 2 from #97). A more comprehensive solution (e.g., constrained k-means with min cluster sizes) could follow later.

### Changes

- `reddwarf/utils/clusterer/kmeans.py`: Add singleton check before `silhouette_score` in the scoring function
- `tests/utils/clusterer/test_kmeans.py`: Add test with synthetic data (two dense clusters + one outlier) verifying singleton k values are rejected